### PR TITLE
Returning additional values in availability, saving process pu/do

### DIFF
--- a/__fixtures__/OptionInfoRequest_4713b24a3b7a061e0a2532143c72524af88b7988.txt
+++ b/__fixtures__/OptionInfoRequest_4713b24a3b7a061e0a2532143c72524af88b7988.txt
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TESTEXTPICKUPDROPOFF</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptGeneral>
+                <SupplierId>4109</SupplierId>
+                <SupplierName>Test External Supplier</SupplierName>
+                <Description>City Tour with Pickup and Dropoff</Description>
+                <Description2 />
+                <Comment />
+                <Comment2 />
+                <Locality>TEST</Locality>
+                <LocalityDescription>Test Metro</LocalityDescription>
+                <SType>N</SType>
+                <MPFCU>1</MPFCU>
+                <VoucherName>Test External Supplier</VoucherName>
+                <Address1>123 Test Street</Address1>
+                <Address2>Test City, TC 12345</Address2>
+                <Address3 />
+                <Address4 />
+                <Address5 />
+                <PostCode>12345</PostCode>
+                <InfantsAllowed>Y</InfantsAllowed>
+                <Infant_From>0</Infant_From>
+                <Infant_To>1</Infant_To>
+                <ChildrenAllowed>Y</ChildrenAllowed>
+                <Child_From>2</Child_From>
+                <Child_To>15</Child_To>
+                <AdultsAllowed>Y</AdultsAllowed>
+                <Adult_From>16</Adult_From>
+                <Adult_To>999</Adult_To>
+                <PromptForPuDo>Y</PromptForPuDo>
+                <ButtonName>Sightseeing</ButtonName>
+                <DBAnalysisCode1 />
+                <DBAnalysisDescription1>Unassigned</DBAnalysisDescription1>
+                <DBAnalysisCode2>CT</DBAnalysisCode2>
+                <DBAnalysisDescription2>Classic Day Tours</DBAnalysisDescription2>
+                <DBAnalysisCode3 />
+                <DBAnalysisDescription3>Unassigned</DBAnalysisDescription3>
+                <DBAnalysisCode4>30</DBAnalysisCode4>
+                <DBAnalysisDescription4>6.67% mark-up no rounding</DBAnalysisDescription4>
+                <DBAnalysisCode5>40</DBAnalysisCode5>
+                <DBAnalysisDescription5>25% comm - 6.67% (8%) mup non-accom</DBAnalysisDescription5>
+                <DBAnalysisCode6 />
+                <DBAnalysisDescription6>Unassigned</DBAnalysisDescription6>
+                <LastUpdate>2025-01-15T10:30:00Z</LastUpdate>
+            </OptGeneral>
+            <OptStayResults>
+                <Availability>OK</Availability>
+                <Currency>USD</Currency>
+                <TotalPrice>150000</TotalPrice>
+                <CommissionPercent>0.00</CommissionPercent>
+                <AgentPrice>115450</AgentPrice>
+                <RateId>$USDtest123456789,4,DOUB,EXT TEST RATE</RateId>
+                <RateName>External Test Rate</RateName>
+                <RateText>Standard</RateText>
+                <PeriodValueAdds>
+                    <PeriodValueAdd>
+                        <DateFrom>2025-04-01</DateFrom>
+                        <DateTo>2025-04-01</DateTo>
+                        <RateName>Test Rate</RateName>
+                        <RateText>Standard</RateText>
+                    </PeriodValueAdd>
+                </PeriodValueAdds>
+                <CancelHours>24</CancelHours>
+                <Prefer>1</Prefer>
+                <ExternalRateDetails>
+                    <ExtSupplierId>TEST001</ExtSupplierId>
+                    <ExtOptionId>EXTTOUR</ExtOptionId>
+                    <ExtOptionDescr>City Tour with Pickup and Dropoff</ExtOptionDescr>
+                    <ExtRatePlanCode>EXT TEST RATE</ExtRatePlanCode>
+                    <ExtRatePlanDescr>Full Day Tour</ExtRatePlanDescr>
+                    <ExtGuarantee>Y</ExtGuarantee>
+                    <ExtStartTimes>
+                        <ExtStartTime>2025-04-01T08:00:00</ExtStartTime>
+                        <ExtStartTime>2025-04-01T09:00:00</ExtStartTime>
+                        <ExtStartTime>2025-04-01T10:00:00</ExtStartTime>
+                        <ExtStartTime>2025-04-01T11:00:00</ExtStartTime>
+                    </ExtStartTimes>
+                    <ExtPickupDetails>
+                        <ExtPickupDetail>
+                            <ExtPointName>Central Hotel</ExtPointName>
+                            <MinutesPrior>30</MinutesPrior>
+                            <Address>123 Main Street, Downtown</Address>
+                            <ExtPointInfo>Meet at hotel lobby entrance</ExtPointInfo>
+                        </ExtPickupDetail>
+                        <ExtPickupDetail>
+                            <ExtPointName>Airport Terminal</ExtPointName>
+                            <MinutesPrior>45</MinutesPrior>
+                            <Address>Airport Terminal 1, International Arrivals</Address>
+                            <ExtPointInfo>Look for guide with company sign</ExtPointInfo>
+                        </ExtPickupDetail>
+                        <ExtPickupDetail>
+                            <ExtPointName>Train Station</ExtPointName>
+                            <MinutesPrior>20</MinutesPrior>
+                            <Address>Central Station, Platform 3</Address>
+                            <ExtPointInfo>Meet at information desk</ExtPointInfo>
+                        </ExtPickupDetail>
+                    </ExtPickupDetails>
+                    <ExtDropoffDetails>
+                        <ExtDropoffDetail>
+                            <ExtPointName>Tourist Center</ExtPointName>
+                            <MinutesPrior>15</MinutesPrior>
+                            <Address>Tourist Information Center, City Square</Address>
+                            <ExtPointInfo>Drop at main entrance</ExtPointInfo>
+                        </ExtDropoffDetail>
+                        <ExtDropoffDetail>
+                            <ExtPointName>Hotel District</ExtPointName>
+                            <MinutesPrior>10</MinutesPrior>
+                            <Address>456 Hotel Boulevard, Luxury District</Address>
+                            <ExtPointInfo>Drop at hotel entrance</ExtPointInfo>
+                        </ExtDropoffDetail>
+                    </ExtDropoffDetails>
+                    <CancelPolicies>
+                        <CancelPenalty>
+                            <PenaltyDescription>No refund for cancellations within 2 hours of tour start</PenaltyDescription>
+                        </CancelPenalty>
+                        <CancelPenalty>
+                            <Deadline>
+                                <OffsetUnitMultiplier>2</OffsetUnitMultiplier>
+                                <OffsetTimeUnit>Hour</OffsetTimeUnit>
+                            </Deadline>
+                            <PenaltyDescription>50% refund for cancellations 2-24 hours before tour</PenaltyDescription>
+                        </CancelPenalty>
+                        <CancelPenalty>
+                            <Deadline>
+                                <OffsetUnitMultiplier>24</OffsetUnitMultiplier>
+                                <OffsetTimeUnit>Hour</OffsetTimeUnit>
+                            </Deadline>
+                            <PenaltyDescription>Full refund for cancellations more than 24 hours before tour</PenaltyDescription>
+                        </CancelPenalty>
+                    </CancelPolicies>
+                    <AdditionalDetails>
+                        <AdditionalDetail>
+                            <DetailName>FullDescription</DetailName>
+                            <DetailDescription>Experience the best of our city with this comprehensive tour that includes convenient pickup and dropoff services. This full-day adventure takes you to all the must-see attractions while providing comfortable transportation throughout your journey.</DetailDescription>
+                        </AdditionalDetail>
+                        <AdditionalDetail>
+                            <DetailName>TourDuration</DetailName>
+                            <DetailDescription>8 hours</DetailDescription>
+                        </AdditionalDetail>
+                        <AdditionalDetail>
+                            <DetailName>Itinerary</DetailName>
+                            <DetailDescription>Your tour begins with pickup from your designated location. You'll visit the historic downtown area, explore the cultural district, enjoy lunch at a local restaurant, and conclude with dropoff at your preferred location. The tour includes professional guide services and all entrance fees.</DetailDescription>
+                        </AdditionalDetail>
+                    </AdditionalDetails>
+                </ExternalRateDetails>
+                <RoomList>
+                    <RoomType>DB</RoomType>
+                </RoomList>
+            </OptStayResults>
+        </Option>
+    </OptionInfoReply>
+</Reply> 

--- a/__fixtures__/OptionInfoRequest_91937b8a3b31f82e4e3e5f61943f661ad9bc082e.txt
+++ b/__fixtures__/OptionInfoRequest_91937b8a3b31f82e4e3e5f61943f661ad9bc082e.txt
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TESTTOPLEVELCANCELPOLICIES</Opt>
+            <OptionNumber>46052</OptionNumber>
+            <OptStayResults>
+                <Availability>OK</Availability>
+                <Currency>NZD</Currency>
+                <TotalPrice>109800</TotalPrice>
+                <CommissionPercent>0.00</CommissionPercent>
+                <AgentPrice>109800</AgentPrice>
+                <RateId>$NZD9704dbc4eaf60700,4,DOUB,C5 A1INF KGB DOUB RONL</RateId>
+                <RateName />
+                <PeriodValueAdds>
+                    <PeriodValueAdd>
+                        <DateFrom>2025-04-01</DateFrom>
+                        <DateTo>2025-04-01</DateTo>
+                        <RateName />
+                    </PeriodValueAdd>
+                </PeriodValueAdds>
+                <CancelPolicies>
+                    <CancelPenalty>
+                        <Deadline>
+                            <OffsetUnitMultiplier>72</OffsetUnitMultiplier>
+                            <OffsetTimeUnit>Hour</OffsetTimeUnit>
+                            <DeadlineDateTime>2025-03-29T11:00:00Z</DeadlineDateTime>
+                        </Deadline>
+                        <InEffect>Y</InEffect>
+                        <LinePrice>97876</LinePrice>
+                        <AgentPrice>97876</AgentPrice>
+                        <PenaltyDescription>72 hours prior to arrival - 10% cancellation fee</PenaltyDescription>
+                    </CancelPenalty>
+                    <CancelPenalty>
+                        <Deadline>
+                            <OffsetUnitMultiplier>24</OffsetUnitMultiplier>
+                            <OffsetTimeUnit>Hour</OffsetTimeUnit>
+                            <DeadlineDateTime>2025-03-31T11:00:00Z</DeadlineDateTime>
+                        </Deadline>
+                        <InEffect>Y</InEffect>
+                        <LinePrice>54900</LinePrice>
+                        <AgentPrice>54900</AgentPrice>
+                        <PenaltyDescription>24 hours prior to arrival - 50% cancellation fee</PenaltyDescription>
+                    </CancelPenalty>
+                    <CancelPenalty>
+                        <Deadline>
+                            <OffsetUnitMultiplier>0</OffsetUnitMultiplier>
+                            <OffsetTimeUnit>Hour</OffsetTimeUnit>
+                            <DeadlineDateTime>2025-04-01T11:00:00Z</DeadlineDateTime>
+                        </Deadline>
+                        <InEffect>Y</InEffect>
+                        <LinePrice>109800</LinePrice>
+                        <AgentPrice>109800</AgentPrice>
+                        <PenaltyDescription>No show or same day cancellation - 100% cancellation fee</PenaltyDescription>
+                    </CancelPenalty>
+                </CancelPolicies>
+                <ExternalRateDetails>
+                    <ExtSupplierId>NZ000021</ExtSupplierId>
+                    <ExtOptionId>DOUB</ExtOptionId>
+                    <ExtOptionDescr>Superior Room, 1 King Bed</ExtOptionDescr>
+                    <ExtRatePlanCode>C5 A1INF KGB DOUB RONL</ExtRatePlanCode>
+                    <ExtRatePlanDescr>Room Only</ExtRatePlanDescr>
+                    <ExtGuarantee>N</ExtGuarantee>
+                    <ExtStartTimes>
+                        <ExtStartTime>2025-04-01T06:30:00</ExtStartTime>
+                        <ExtStartTime>2025-04-01T07:30:00</ExtStartTime>
+                        <ExtStartTime>2025-04-01T08:30:00</ExtStartTime>
+                    </ExtStartTimes>
+                    <ExtPickupDetails>
+                        <ExtPickupDetail>
+                            <ExtPointName>Adina/Vibe Waterfront</ExtPointName>
+                            <MinutesPrior>30</MinutesPrior>
+                            <Address>7 Kitchener Dr, Darwin</Address>
+                            <ExtPointInfo>Meet at hotel lobby</ExtPointInfo>
+                        </ExtPickupDetail>
+                        <ExtPickupDetail>
+                            <ExtPointName>Argus Hotel</ExtPointName>
+                            <MinutesPrior>30</MinutesPrior>
+                            <Address>13 Shepherd St, Darwin (Front of Hotel)</Address>
+                            <ExtPointInfo>Additional pickup information</ExtPointInfo>
+                        </ExtPickupDetail>
+                    </ExtPickupDetails>
+                    <ExtDropoffDetails>
+                        <ExtDropoffDetail>
+                            <ExtPointName>Airport Terminal</ExtPointName>
+                            <MinutesPrior>15</MinutesPrior>
+                            <Address>Airport Terminal 1, Darwin</Address>
+                            <ExtPointInfo>Drop at arrivals hall</ExtPointInfo>
+                        </ExtDropoffDetail>
+                    </ExtDropoffDetails>
+                    <CancelPolicies>
+                        <CancelPenalty>
+                            <PenaltyDescription>Cancellation 100% - within 24 hours or no notice</PenaltyDescription>
+                        </CancelPenalty>
+                        <CancelPenalty>
+                            <Deadline>
+                                <OffsetUnitMultiplier>2</OffsetUnitMultiplier>
+                                <OffsetTimeUnit>Day</OffsetTimeUnit>
+                            </Deadline>
+                            <PenaltyDescription>Day Tour Cancellation within 48hrs - 50%</PenaltyDescription>
+                        </CancelPenalty>
+                    </CancelPolicies>
+                </ExternalRateDetails>
+                <RoomList>
+                    <RoomType>DB</RoomType>
+                </RoomList>
+            </OptStayResults>
+            <OptStayResults>
+                <Availability>OK</Availability>
+                <Currency>NZD</Currency>
+                <TotalPrice>117200</TotalPrice>
+                <CommissionPercent>0.00</CommissionPercent>
+                <AgentPrice>117200</AgentPrice>
+                <RateId>$NZD454c5fffb6a75a39,4,DOUB,C5 B1INF KGBH DOUB BRKF</RateId>
+                <RateName />
+                <PeriodValueAdds>
+                    <PeriodValueAdd>
+                        <DateFrom>2025-04-01</DateFrom>
+                        <DateTo>2025-04-01</DateTo>
+                        <RateName />
+                    </PeriodValueAdd>
+                </PeriodValueAdds>
+                <CancelPolicies>
+                    <CancelPenalty>
+                        <Deadline>
+                            <OffsetUnitMultiplier>48</OffsetUnitMultiplier>
+                            <OffsetTimeUnit>Hour</OffsetTimeUnit>
+                            <DeadlineDateTime>2025-03-30T11:00:00Z</DeadlineDateTime>
+                        </Deadline>
+                        <InEffect>Y</InEffect>
+                        <LinePrice>104524</LinePrice>
+                        <AgentPrice>104524</AgentPrice>
+                        <PenaltyDescription>48 hours prior to arrival - 10% cancellation fee</PenaltyDescription>
+                    </CancelPenalty>
+                    <CancelPenalty>
+                        <Deadline>
+                            <OffsetUnitMultiplier>0</OffsetUnitMultiplier>
+                            <OffsetTimeUnit>Hour</OffsetTimeUnit>
+                            <DeadlineDateTime>2025-04-01T11:00:00Z</DeadlineDateTime>
+                        </Deadline>
+                        <InEffect>Y</InEffect>
+                        <LinePrice>117200</LinePrice>
+                        <AgentPrice>117200</AgentPrice>
+                        <PenaltyDescription>No show or same day cancellation - 100% cancellation fee</PenaltyDescription>
+                    </CancelPenalty>
+                </CancelPolicies>
+                <ExternalRateDetails>
+                    <ExtSupplierId>NZ000021</ExtSupplierId>
+                    <ExtOptionId>DOUB</ExtOptionId>
+                    <ExtOptionDescr>Accessible Superior Room, 1 King Bed</ExtOptionDescr>
+                    <ExtRatePlanCode>C5 B1INF KGBH DOUB BRKF</ExtRatePlanCode>
+                    <ExtRatePlanDescr>Breakfast</ExtRatePlanDescr>
+                    <ExtGuarantee>N</ExtGuarantee>
+                </ExternalRateDetails>
+                <RoomList>
+                    <RoomType>DB</RoomType>
+                </RoomList>
+            </OptStayResults>
+            <OptStayResults>
+                <Availability>OK</Availability>
+                <Currency>NZD</Currency>
+                <TotalPrice>123600</TotalPrice>
+                <CommissionPercent>0.00</CommissionPercent>
+                <AgentPrice>123600</AgentPrice>
+                <RateId>$NZDdf6f8ddcab337053,4,DOUB,C5 A1INF KGA DOUB RONL</RateId>
+                <RateName />
+                <PeriodValueAdds>
+                    <PeriodValueAdd>
+                        <DateFrom>2025-04-01</DateFrom>
+                        <DateTo>2025-04-01</DateTo>
+                        <RateName />
+                    </PeriodValueAdd>
+                </PeriodValueAdds>
+                <CancelPolicies>
+                    <CancelPenalty>
+                        <Deadline>
+                            <OffsetUnitMultiplier>96</OffsetUnitMultiplier>
+                            <OffsetTimeUnit>Hour</OffsetTimeUnit>
+                            <DeadlineDateTime>2025-03-28T11:00:00Z</DeadlineDateTime>
+                        </Deadline>
+                        <InEffect>Y</InEffect>
+                        <LinePrice>110340</LinePrice>
+                        <AgentPrice>110340</AgentPrice>
+                        <PenaltyDescription>96 hours prior to arrival - 10% cancellation fee</PenaltyDescription>
+                    </CancelPenalty>
+                    <CancelPenalty>
+                        <Deadline>
+                            <OffsetUnitMultiplier>48</OffsetUnitMultiplier>
+                            <OffsetTimeUnit>Hour</OffsetTimeUnit>
+                            <DeadlineDateTime>2025-03-30T11:00:00Z</DeadlineDateTime>
+                        </Deadline>
+                        <InEffect>Y</InEffect>
+                        <LinePrice>61800</LinePrice>
+                        <AgentPrice>61800</AgentPrice>
+                        <PenaltyDescription>48 hours prior to arrival - 50% cancellation fee</PenaltyDescription>
+                    </CancelPenalty>
+                    <CancelPenalty>
+                        <Deadline>
+                            <OffsetUnitMultiplier>0</OffsetUnitMultiplier>
+                            <OffsetTimeUnit>Hour</OffsetTimeUnit>
+                            <DeadlineDateTime>2025-04-01T11:00:00Z</DeadlineDateTime>
+                        </Deadline>
+                        <InEffect>Y</InEffect>
+                        <LinePrice>123600</LinePrice>
+                        <AgentPrice>123600</AgentPrice>
+                        <PenaltyDescription>No show or same day cancellation - 100% cancellation fee</PenaltyDescription>
+                    </CancelPenalty>
+                </CancelPolicies>
+                <ExternalRateDetails>
+                    <ExtSupplierId>NZ000021</ExtSupplierId>
+                    <ExtOptionId>DOUB</ExtOptionId>
+                    <ExtOptionDescr>Luxury Atrium View Room, 1 King Bed</ExtOptionDescr>
+                    <ExtRatePlanCode>C5 A1INF KGA DOUB RONL</ExtRatePlanCode>
+                    <ExtRatePlanDescr>Room Only</ExtRatePlanDescr>
+                    <ExtGuarantee>N</ExtGuarantee>
+                </ExternalRateDetails>
+                <RoomList>
+                    <RoomType>DB</RoomType>
+                </RoomList>
+            </OptStayResults>
+        </Option>
+    </OptionInfoReply>
+</Reply> 

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -3301,6 +3301,271 @@ Object {
 }
 `;
 
+exports[`search tests searchAvailabilityForItinerary - option cancel policies should handle cancel policies correctly 1`] = `
+Object {
+  "bookable": true,
+  "rates": Array [
+    Object {
+      "additionalDetails": Array [],
+      "agentPrice": 109800,
+      "cancelHours": "",
+      "cancelPolicies": Array [
+        Object {
+          "agentPrice": 97876,
+          "cancelFee": 97876,
+          "cancelNum": 72,
+          "cancelTimeUnit": "Hour",
+          "deadlineDateTime": "2025-03-29T11:00:00Z",
+          "inEffect": true,
+          "penaltyDescription": "72 hours prior to arrival - 10% cancellation fee",
+        },
+        Object {
+          "agentPrice": 54900,
+          "cancelFee": 54900,
+          "cancelNum": 24,
+          "cancelTimeUnit": "Hour",
+          "deadlineDateTime": "2025-03-31T11:00:00Z",
+          "inEffect": true,
+          "penaltyDescription": "24 hours prior to arrival - 50% cancellation fee",
+        },
+        Object {
+          "agentPrice": 109800,
+          "cancelFee": 109800,
+          "cancelNum": 0,
+          "cancelTimeUnit": "Hour",
+          "deadlineDateTime": "2025-04-01T11:00:00Z",
+          "inEffect": true,
+          "penaltyDescription": "No show or same day cancellation - 100% cancellation fee",
+        },
+      ],
+      "currency": "NZD",
+      "doInfoList": Array [
+        Object {
+          "Address": "Airport Terminal 1, Darwin",
+          "ExtPointInfo": "Drop at arrivals hall",
+          "ExtPointName": "Airport Terminal",
+          "MinutesPrior": 15,
+        },
+      ],
+      "externalRateText": "Superior Room, 1 King Bed (Room Only)",
+      "puInfoList": Array [
+        Object {
+          "address": "7 Kitchener Dr, Darwin",
+          "minutesPrior": 30,
+          "pointInfo": "Meet at hotel lobby",
+          "pointName": "Adina/Vibe Waterfront",
+        },
+        Object {
+          "address": "13 Shepherd St, Darwin (Front of Hotel)",
+          "minutesPrior": 30,
+          "pointInfo": "Additional pickup information",
+          "pointName": "Argus Hotel",
+        },
+      ],
+      "rateId": "$NZD9704dbc4eaf60700,4,DOUB,C5 A1INF KGB DOUB RONL",
+      "startTimes": Array [
+        Object {
+          "startTime": "06:30",
+        },
+        Object {
+          "startTime": "07:30",
+        },
+        Object {
+          "startTime": "08:30",
+        },
+      ],
+      "totalPrice": 109800,
+      "totalPriceCurrencyPrecision": 2,
+    },
+    Object {
+      "additionalDetails": Array [],
+      "agentPrice": 117200,
+      "cancelHours": "",
+      "cancelPolicies": Array [
+        Object {
+          "agentPrice": 104524,
+          "cancelFee": 104524,
+          "cancelNum": 48,
+          "cancelTimeUnit": "Hour",
+          "deadlineDateTime": "2025-03-30T11:00:00Z",
+          "inEffect": true,
+          "penaltyDescription": "48 hours prior to arrival - 10% cancellation fee",
+        },
+        Object {
+          "agentPrice": 117200,
+          "cancelFee": 117200,
+          "cancelNum": 0,
+          "cancelTimeUnit": "Hour",
+          "deadlineDateTime": "2025-04-01T11:00:00Z",
+          "inEffect": true,
+          "penaltyDescription": "No show or same day cancellation - 100% cancellation fee",
+        },
+      ],
+      "currency": "NZD",
+      "doInfoList": Array [],
+      "externalRateText": "Accessible Superior Room, 1 King Bed (Breakfast)",
+      "puInfoList": Array [],
+      "rateId": "$NZD454c5fffb6a75a39,4,DOUB,C5 B1INF KGBH DOUB BRKF",
+      "startTimes": Array [],
+      "totalPrice": 117200,
+      "totalPriceCurrencyPrecision": 2,
+    },
+    Object {
+      "additionalDetails": Array [],
+      "agentPrice": 123600,
+      "cancelHours": "",
+      "cancelPolicies": Array [
+        Object {
+          "agentPrice": 110340,
+          "cancelFee": 110340,
+          "cancelNum": 96,
+          "cancelTimeUnit": "Hour",
+          "deadlineDateTime": "2025-03-28T11:00:00Z",
+          "inEffect": true,
+          "penaltyDescription": "96 hours prior to arrival - 10% cancellation fee",
+        },
+        Object {
+          "agentPrice": 61800,
+          "cancelFee": 61800,
+          "cancelNum": 48,
+          "cancelTimeUnit": "Hour",
+          "deadlineDateTime": "2025-03-30T11:00:00Z",
+          "inEffect": true,
+          "penaltyDescription": "48 hours prior to arrival - 50% cancellation fee",
+        },
+        Object {
+          "agentPrice": 123600,
+          "cancelFee": 123600,
+          "cancelNum": 0,
+          "cancelTimeUnit": "Hour",
+          "deadlineDateTime": "2025-04-01T11:00:00Z",
+          "inEffect": true,
+          "penaltyDescription": "No show or same day cancellation - 100% cancellation fee",
+        },
+      ],
+      "currency": "NZD",
+      "doInfoList": Array [],
+      "externalRateText": "Luxury Atrium View Room, 1 King Bed (Room Only)",
+      "puInfoList": Array [],
+      "rateId": "$NZDdf6f8ddcab337053,4,DOUB,C5 A1INF KGA DOUB RONL",
+      "startTimes": Array [],
+      "totalPrice": 123600,
+      "totalPriceCurrencyPrecision": 2,
+    },
+  ],
+  "type": "inventory",
+}
+`;
+
+exports[`search tests searchAvailabilityForItinerary - other & external pudo info should handle external pickup, dropoff, and start times correctly 1`] = `
+Object {
+  "bookable": true,
+  "rates": Array [
+    Object {
+      "additionalDetails": Array [
+        Object {
+          "detailDescription": "Experience the best of our city with this comprehensive tour that includes convenient pickup and dropoff services. This full-day adventure takes you to all the must-see attractions while providing comfortable transportation throughout your journey.",
+          "detailName": "FullDescription",
+        },
+        Object {
+          "detailDescription": "8 hours",
+          "detailName": "TourDuration",
+        },
+        Object {
+          "detailDescription": "Your tour begins with pickup from your designated location. You'll visit the historic downtown area, explore the cultural district, enjoy lunch at a local restaurant, and conclude with dropoff at your preferred location. The tour includes professional guide services and all entrance fees.",
+          "detailName": "Itinerary",
+        },
+      ],
+      "agentPrice": 115450,
+      "cancelHours": 24,
+      "cancelPolicies": Array [
+        Object {
+          "agentPrice": "",
+          "cancelFee": "",
+          "cancelNum": "",
+          "cancelTimeUnit": "",
+          "deadlineDateTime": "",
+          "inEffect": false,
+          "penaltyDescription": "No refund for cancellations within 2 hours of tour start",
+        },
+        Object {
+          "agentPrice": "",
+          "cancelFee": "",
+          "cancelNum": 2,
+          "cancelTimeUnit": "Hour",
+          "deadlineDateTime": "",
+          "inEffect": false,
+          "penaltyDescription": "50% refund for cancellations 2-24 hours before tour",
+        },
+        Object {
+          "agentPrice": "",
+          "cancelFee": "",
+          "cancelNum": 24,
+          "cancelTimeUnit": "Hour",
+          "deadlineDateTime": "",
+          "inEffect": false,
+          "penaltyDescription": "Full refund for cancellations more than 24 hours before tour",
+        },
+      ],
+      "currency": "USD",
+      "doInfoList": Array [
+        Object {
+          "address": "Tourist Information Center, City Square",
+          "minutesPrior": 15,
+          "pointInfo": "Drop at main entrance",
+          "pointName": "Tourist Center",
+        },
+        Object {
+          "address": "456 Hotel Boulevard, Luxury District",
+          "minutesPrior": 10,
+          "pointInfo": "Drop at hotel entrance",
+          "pointName": "Hotel District",
+        },
+      ],
+      "externalRateText": "City Tour with Pickup and Dropoff (Full Day Tour)",
+      "puInfoList": Array [
+        Object {
+          "address": "123 Main Street, Downtown",
+          "minutesPrior": 30,
+          "pointInfo": "Meet at hotel lobby entrance",
+          "pointName": "Central Hotel",
+        },
+        Object {
+          "address": "Airport Terminal 1, International Arrivals",
+          "minutesPrior": 45,
+          "pointInfo": "Look for guide with company sign",
+          "pointName": "Airport Terminal",
+        },
+        Object {
+          "address": "Central Station, Platform 3",
+          "minutesPrior": 20,
+          "pointInfo": "Meet at information desk",
+          "pointName": "Train Station",
+        },
+      ],
+      "rateId": "$USDtest123456789,4,DOUB,EXT TEST RATE",
+      "startTimes": Array [
+        Object {
+          "startTime": "08:00",
+        },
+        Object {
+          "startTime": "09:00",
+        },
+        Object {
+          "startTime": "10:00",
+        },
+        Object {
+          "startTime": "11:00",
+        },
+      ],
+      "totalPrice": 150000,
+      "totalPriceCurrencyPrecision": 2,
+    },
+  ],
+  "type": "inventory",
+}
+`;
+
 exports[`search tests searchItineraries 1`] = `
 Object {
   "bookings": Array [

--- a/resolvers/product.js
+++ b/resolvers/product.js
@@ -25,7 +25,7 @@ const resolvers = {
       const lastUpdateISO = R.path(['OptGeneral', 'LastUpdate'], option);
       return lastUpdateISO ? new Date(lastUpdateISO).getTime() / 1000 : null;
     },
-    // Guides, Accommodation, Transfers, Entrance Fees, Meals, Other
+    // Guides, Accommodation, Transfers, Entrance Fees, Meals, Rail, Sightseeing Other
     serviceType: option => {
       const st = R.pathOr('', ['OptGeneral', 'ButtonName'], option);
       return typeof st === 'string' ? st : '';


### PR DESCRIPTION
This is related to TC-395 ( https://tourconnect.atlassian.net/browse/TC-395). The availability check now returns the following additional attributes:

1. currency
2. totalPrice
3. agentPrice
4. totalPriceCurrencyPrecision
5. cancelHours
6. cancelPolicies
7. startTimes
8. puInfoList
9. doInfoList
10. additionalDetails,

Two tests added:
1. To test the handling of ALL new values in searchAvailabilityForItinerary
2. To test the handling of Cancellation policies on option level (the cancel policies can also be in external rate. but the top level get priority. if not found we use the one inside ExternalRateDetails. (case 1 above)