### PR TITLE
TC 518:  Updated message text & enabled  "Send Services Without A Rate" irrespective whether custom rates are enabled or not

### DIFF
--- a/availability/itinerary-availability.js
+++ b/availability/itinerary-availability.js
@@ -29,10 +29,9 @@ const GENERIC_AVALABILITY_CHK_ERROR_MESSAGE = 'Not bookable for the requested da
 const EXTENDED_BOOKING_YEARS_ERROR_TEMPLATE = 'Last available rate until: {lastRateEndDate}. Custom rates can only be extended by {extendedBookingYears} year(s), please change the date and try again.';
 const MIN_STAY_WARNING_MESSAGE = 'Please note that the previous rate had a minimum stay requirement of {minSCU}.';
 const PREVIOUS_RATE_CLOSED_PERIODS_WARNING_MESSAGE = 'Not bookable for the requested date/stay using {customPeriodInfoMsg} {closedDateRanges}';
-const NO_RATE_FOUND_FOR_LAST_YEAR_ERROR_MESSAGE = 'Custom rates cannot be calculated as no rates found for the last year for the requested date/stay. Please change the date and try again.';
+const NO_RATE_FOUND_FOR_LAST_YEAR_ERROR_MESSAGE = 'Custom rates cannot be calculated as the previous year\'s rate could not be found. Please change the date and try again.';
 const NO_RATE_FOUND_FOR_IMMEDIATE_LAST_DATE_RANGE_ERROR_MESSAGE = 'Custom rates cannot be calculated no last rates available. Please change the date and try again.';
-const SERVICE_WITHOUT_A_RATE_APPLIED_ERROR_MESSAGE = 'No rates available for the requested date/stay. But you can add the service without any rates.';
-const INVALID_CURRENCY_CODE_ERROR_MESSAGE = 'In order to send service without rates, please select the currency in the plugin settings.';
+const SERVICE_WITHOUT_A_RATE_APPLIED_ERROR_MESSAGE = 'No rates available for the requested date/stay. Rates will be sent as 0.00 per your company settings.';
 
 const doAllDatesHaveRatesAvailable = (lastDateRangeEndDate, startDate, chargeUnitQuantity) => {
   const ratesRequiredTillDate = moment(startDate).add(chargeUnitQuantity - 1, 'days').format('YYYY-MM-DD');

--- a/availability/itinerary-availability.js
+++ b/availability/itinerary-availability.js
@@ -293,8 +293,9 @@ const searchAvailabilityForItinerary = async ({
   }
 
   // At least one date does not have rates available.
-  if (!isBookingForCustomRatesEnabled) {
-    // If custom rates are not enabled, return error
+  if (!isBookingForCustomRatesEnabled && !allowSendingServicesWithoutARate) {
+    // If both "custom rates" and "sending services without a rate" are not enabled
+    // return error
     return getNoRatesAvailableError({
       optionId,
       hostConnectEndpoint,
@@ -308,7 +309,7 @@ const searchAvailabilityForItinerary = async ({
     });
   }
 
-  // Custom Rates are Enabled
+  // Custom Rates are Enabled or Sending Services Without a Rate is Enabled
   // Step1 : Get date range to use for the days that do not have any rates available
   // This is done by getting the past rates based on the useLastYearRate flag.
   // If true use last year's rates, otherwise use last available rates.


### PR DESCRIPTION
1.  "Send Services Without A Rate" should work irrespective whether  "Custom Rates Enable For Quotes And Bookings" is  
enabled or disabled
2. Updated message text