### PR TITLE
hotfix: Sanitize "agent ref" to remove ascented characters

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,6 +16,7 @@ jobs:
       - run: npm run build --if-present
       - run: npm test
         env:
+          TZ: UTC
           ti2_tourplan_endpoint: ${{ secrets.TOURPLAN_ENDPOINT }}
           ti2_tourplan_username: ${{ secrets.TOURPLAN_USERNAME }}
           ti2_tourplan_password: ${{ secrets.TOURPLAN_PASSWORD }}

--- a/__fixtures__/AgentInfoRequest_71ba7f3378a75752ec6e823a4d8f95f98f489e15.txt
+++ b/__fixtures__/AgentInfoRequest_71ba7f3378a75752ec6e823a4d8f95f98f489e15.txt
@@ -1,0 +1,7 @@
+<!DOCTYPE Reply SYSTEM "hostConnect_4_06_009.dtd"[]>
+<Reply>
+  <AgentInfoReply>
+    <AgentID>test_hostConnectAgentID</AgentID>
+    <Status>Error</Status>
+  </AgentInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_02bbd5d85a6d76c48ed9183b33efbabd9e606587.txt
+++ b/__fixtures__/OptionInfoRequest_02bbd5d85a6d76c48ed9183b33efbabd9e606587.txt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_DO_NOT_APPLY_EXTENDED_BOOKING_YEARS_LIMIT_WHEN_CURRENT_RATES_ARE_AVAILABLE</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptStayResults>
+                <Availability>OK</Availability>
+                <Currency>NZD</Currency>
+                <TotalPrice>50000</TotalPrice>
+                <CommissionPercent>0.00</CommissionPercent>
+                <AgentPrice>55000</AgentPrice>
+                <RateId>Standard</RateId>
+                <RateName />
+                <PeriodValueAdds>
+                    <PeriodValueAdd>
+                        <DateFrom>2027-08-01</DateFrom>
+                        <DateTo>2027-08-02</DateTo>
+                        <RateName />
+                    </PeriodValueAdd>
+                </PeriodValueAdds>
+                <RoomList>
+                    <RoomType>DB</RoomType>
+                </RoomList>
+            </OptStayResults>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_041518de9a66121c66d07901e0e2aa352ed55f34.txt
+++ b/__fixtures__/OptionInfoRequest_041518de9a66121c66d07901e0e2aa352ed55f34.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_NULL_EXTENDED_BOOKING_YEARS</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2025-08-01</DateFrom>
+                    <DateTo>2025-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>50000</SingleRate>
+                                    <DoubleRate>50000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_0b2a44959e1d31f7c6bbe632d43b7667dd3105f5.txt
+++ b/__fixtures__/OptionInfoRequest_0b2a44959e1d31f7c6bbe632d43b7667dd3105f5.txt
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_LAST_AVAILABLE_RATE</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2026-03-22</DateFrom>
+                    <DateTo>2026-04-30</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>60000</SingleRate>
+                                    <DoubleRate>60000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+                <OptDateRange>
+                    <DateFrom>2025-08-01</DateFrom>
+                    <DateTo>2025-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>61000</SingleRate>
+                                    <DoubleRate>61000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_0dc140f713f4d8c5ca009adb162f5821c90e0b4e.txt
+++ b/__fixtures__/OptionInfoRequest_0dc140f713f4d8c5ca009adb162f5821c90e0b4e.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>LONTRDAVIDSHDWBVC</Opt>
+            <OptionNumber>12345</OptionNumber>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_0ee531c606159cc4d5ff6229ed3944c3dcdcac04.txt
+++ b/__fixtures__/OptionInfoRequest_0ee531c606159cc4d5ff6229ed3944c3dcdcac04.txt
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_LAST_AVAILABLE_RATE</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2026-03-22</DateFrom>
+                    <DateTo>2026-04-30</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>60000</SingleRate>
+                                    <DoubleRate>60000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+                <OptDateRange>
+                    <DateFrom>2025-08-01</DateFrom>
+                    <DateTo>2025-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>61000</SingleRate>
+                                    <DoubleRate>61000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_228e70a16102c1234f884d4eaf637ccceba0ed33.txt
+++ b/__fixtures__/OptionInfoRequest_228e70a16102c1234f884d4eaf637ccceba0ed33.txt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_USE_VALID_EXTENDED_BOOKING_YEARS</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptStayResults>
+                <Availability>OK</Availability>
+                <Currency>NZD</Currency>
+                <TotalPrice>50000</TotalPrice>
+                <CommissionPercent>0.00</CommissionPercent>
+                <AgentPrice>55000</AgentPrice>
+                <RateId>Custom</RateId>
+                <RateName />
+                <PeriodValueAdds>
+                    <PeriodValueAdd>
+                        <DateFrom>2027-01-01</DateFrom>
+                        <DateTo>2027-01-02</DateTo>
+                        <RateName />
+                    </PeriodValueAdd>
+                </PeriodValueAdds>
+                <RoomList>
+                    <RoomType>DB</RoomType>
+                </RoomList>
+            </OptStayResults>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_2bb2a6434a8ed10f9be236d937981486ab228a8a.txt
+++ b/__fixtures__/OptionInfoRequest_2bb2a6434a8ed10f9be236d937981486ab228a8a.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_NO_IMMEDIATE_LAST_DATE_RANGE</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2025-08-01</DateFrom>
+                    <DateTo>2025-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>50000</SingleRate>
+                                    <DoubleRate>50000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_4ffe70f5c9c5044956fda81447f718bc6b92aa83.txt
+++ b/__fixtures__/OptionInfoRequest_4ffe70f5c9c5044956fda81447f718bc6b92aa83.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_HISTORICAL_RATE_NO_DATE_RANGES</Opt>
+            <OptionNumber>12345</OptionNumber>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_60bb0237974131d3fb41e5729e4e6af30e1fdf65.txt
+++ b/__fixtures__/OptionInfoRequest_60bb0237974131d3fb41e5729e4e6af30e1fdf65.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_USE_MINIMUM_EXTENDED_BOOKING_YEARS</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2025-08-01</DateFrom>
+                    <DateTo>2025-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>50000</SingleRate>
+                                    <DoubleRate>50000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_64b89da94d47196c6b0c24a390a8a9c84fac4c97.txt
+++ b/__fixtures__/OptionInfoRequest_64b89da94d47196c6b0c24a390a8a9c84fac4c97.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_HISTORICAL_RATE_MAX_EXTENDED_BOOKING_YEARS</Opt>
+            <OptionNumber>12345</OptionNumber>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_6ee7c4d08ac67523e3f4c196fcc1b1c95ff751f5.txt
+++ b/__fixtures__/OptionInfoRequest_6ee7c4d08ac67523e3f4c196fcc1b1c95ff751f5.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_USE_DEFAULT_EXTENDED_BOOKING_YEARS</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2025-08-01</DateFrom>
+                    <DateTo>2025-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>50000</SingleRate>
+                                    <DoubleRate>50000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_764aec24ee782eadd1ef82d13342131d9f54b710.txt
+++ b/__fixtures__/OptionInfoRequest_764aec24ee782eadd1ef82d13342131d9f54b710.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_HISTORICAL_RATE_NO_DATE_RANGES</Opt>
+            <OptionNumber>12345</OptionNumber>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_80ee0bba696ae843ce920498baa9f3bfce364ccc.txt
+++ b/__fixtures__/OptionInfoRequest_80ee0bba696ae843ce920498baa9f3bfce364ccc.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_HISTORICAL_RATE_NO_DATE_RANGES</Opt>
+            <OptionNumber>12345</OptionNumber>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_82d0a2ff2681e91b80582da450616e358949a491.txt
+++ b/__fixtures__/OptionInfoRequest_82d0a2ff2681e91b80582da450616e358949a491.txt
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_LIMIT_EXTENDED_BOOKING_YEARS</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2026-03-22</DateFrom>
+                    <DateTo>2026-04-30</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>60000</SingleRate>
+                                    <DoubleRate>58000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+                <OptDateRange>
+                    <DateFrom>2025-08-01</DateFrom>
+                    <DateTo>2025-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>54900</SingleRate>
+                                    <DoubleRate>54900</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_86c90d591e684fe1cd16cfbfb87e6e9e3a20b844.txt
+++ b/__fixtures__/OptionInfoRequest_86c90d591e684fe1cd16cfbfb87e6e9e3a20b844.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_USE_VALID_EXTENDED_BOOKING_YEARS</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2027-01-01</DateFrom>
+                    <DateTo>2027-12-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>50000</SingleRate>
+                                    <DoubleRate>55000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_8bca278820d74704d4c30f838510056ffaf711b8.txt
+++ b/__fixtures__/OptionInfoRequest_8bca278820d74704d4c30f838510056ffaf711b8.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_BOOKING_PERIOD_EXCEEDS_EXTENDED_BOOKING_YEARS_LIMIT</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2025-08-01</DateFrom>
+                    <DateTo>2025-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>50000</SingleRate>
+                                    <DoubleRate>55000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_8cf428512f1ab6d0b10e847ad10090d16d8871a5.txt
+++ b/__fixtures__/OptionInfoRequest_8cf428512f1ab6d0b10e847ad10090d16d8871a5.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_VALID_MARKUP_PERCENTAGE</Opt>
+            <OptionNumber>46054</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2027-01-01</DateFrom>
+                    <DateTo>2027-12-31</DateTo>
+                    <Currency>USD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>10000</SingleRate>
+                                    <DoubleRate>10000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_a2b4b570134de60dccdd75ee7b40524dac83bcce.txt
+++ b/__fixtures__/OptionInfoRequest_a2b4b570134de60dccdd75ee7b40524dac83bcce.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>LONTRDAVIDSHDWBVC</Opt>
+            <OptionNumber>12345</OptionNumber>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_a87064a1cad27d7dc09a37c2b7cf157811bf8fcb.txt
+++ b/__fixtures__/OptionInfoRequest_a87064a1cad27d7dc09a37c2b7cf157811bf8fcb.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_BOOKING_PERIOD_AT_BOUNDARY_OF_EXTENDED_BOOKING_YEARS_LIMIT</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2025-08-01</DateFrom>
+                    <DateTo>2025-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>50000</SingleRate>
+                                    <DoubleRate>55000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_ab8a58ec33f66a9537afb46c7b69842912a494b0.txt
+++ b/__fixtures__/OptionInfoRequest_ab8a58ec33f66a9537afb46c7b69842912a494b0.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>LONTRDAVIDSHDWBVC</Opt>
+            <OptionNumber>12345</OptionNumber>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_abe585dfa4494a4cf0a6bbd62180b4a44d309182.txt
+++ b/__fixtures__/OptionInfoRequest_abe585dfa4494a4cf0a6bbd62180b4a44d309182.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_HISTORICAL_RATE_MAX_EXTENDED_BOOKING_YEARS</Opt>
+            <OptionNumber>12345</OptionNumber>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_ae2cfbb553d828aa717a5afd8047e6238ddab364.txt
+++ b/__fixtures__/OptionInfoRequest_ae2cfbb553d828aa717a5afd8047e6238ddab364.txt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_VALID_MARKUP_PERCENTAGE</Opt>
+            <OptionNumber>46054</OptionNumber>
+            <OptStayResults>
+                <Availability>OK</Availability>
+                <Currency>USD</Currency>
+                <TotalPrice>10000</TotalPrice>
+                <CommissionPercent>0.00</CommissionPercent>
+                <AgentPrice>9000</AgentPrice>
+                <RateId>Custom</RateId>
+                <RateName />
+                <PeriodValueAdds>
+                    <PeriodValueAdd>
+                        <DateFrom>2027-01-01</DateFrom>
+                        <DateTo>2027-01-01</DateTo>
+                        <RateName />
+                    </PeriodValueAdd>
+                </PeriodValueAdds>
+                <RoomList>
+                    <RoomType>DB</RoomType>
+                </RoomList>
+            </OptStayResults>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_b350e48f6c156a532c4b00156ba15a21443e40e9.txt
+++ b/__fixtures__/OptionInfoRequest_b350e48f6c156a532c4b00156ba15a21443e40e9.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_USE_VALID_BOOKING_YEARS_AS_STRING</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2025-08-01</DateFrom>
+                    <DateTo>2025-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>50000</SingleRate>
+                                    <DoubleRate>55000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_baf9cee642871f44d6a0ce694cf522bda8ee3cdf.txt
+++ b/__fixtures__/OptionInfoRequest_baf9cee642871f44d6a0ce694cf522bda8ee3cdf.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_HISTORICAL_RATE_LAST_DATE_RANGE</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2024-07-01</DateFrom>
+                    <DateTo>2024-12-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>50000</SingleRate>
+                                    <DoubleRate>50000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_bbbf10fab33abf279a52a8283c6a619a09944a2c.txt
+++ b/__fixtures__/OptionInfoRequest_bbbf10fab33abf279a52a8283c6a619a09944a2c.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_HISTORICAL_RATE_MAX_EXTENDED_BOOKING_YEARS</Opt>
+            <OptionNumber>12345</OptionNumber>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_caef78c731872cbea365df096289d455d8360679.txt
+++ b/__fixtures__/OptionInfoRequest_caef78c731872cbea365df096289d455d8360679.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_USE_MAXIMUM_EXTENDED_BOOKING_YEARS</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2025-08-01</DateFrom>
+                    <DateTo>2025-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>50000</SingleRate>
+                                    <DoubleRate>50000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__fixtures__/OptionInfoRequest_cd9281bbcd98c351c621c2bf6a1352235ae19a99.txt
+++ b/__fixtures__/OptionInfoRequest_cd9281bbcd98c351c621c2bf6a1352235ae19a99.txt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_04_004.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>TEST_OPTION_DO_NOT_APPLY_EXTENDED_BOOKING_YEARS_LIMIT_WHEN_CURRENT_RATES_ARE_AVAILABLE</Opt>
+            <OptionNumber>12345</OptionNumber>
+            <OptDateRanges>
+                <OptDateRange>
+                    <DateFrom>2027-08-01</DateFrom>
+                    <DateTo>2027-08-31</DateTo>
+                    <Currency>NZD</Currency>
+                    <PriceCode>STANDARD</PriceCode>
+                    <RateSets>
+                        <RateSet>
+                            <RateName>Standard Rate</RateName>
+                            <RateText>Standard accommodation rate</RateText>
+                            <MinSCU>1</MinSCU>
+                            <MaxSCU>14</MaxSCU>
+                            <CancelHours>48</CancelHours>
+                            <IsClosed>N</IsClosed>
+                            <ScuCheckOverlapOnly>N</ScuCheckOverlapOnly>
+                            <OptRate>
+                                <RoomRates>
+                                    <SingleRate>50000</SingleRate>
+                                    <DoubleRate>55000</DoubleRate>
+                                </RoomRates>
+                                <ExtrasRates>
+                                    <ExtrasRate>
+                                        <AdultRate>0</AdultRate>
+                                        <ChildRate>0</ChildRate>
+                                        <SequenceNumber>1</SequenceNumber>
+                                    </ExtrasRate>
+                                </ExtrasRates>
+                            </OptRate>
+                        </RateSet>
+                    </RateSets>
+                </OptDateRange>
+            </OptDateRanges>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/index.test.js
+++ b/index.test.js
@@ -1,4 +1,4 @@
-/* globals describe, it, expect, jest, afterEach */
+/* globals describe, it, expect, jest, afterEach, beforeAll, afterAll */
 const { readFile } = require('fs').promises;
 const axios = require('axios');
 const path = require('path');
@@ -83,6 +83,15 @@ const getFixture = async requestObject => {
 
 const app = new Plugin();
 app.callTourplan = mockCallTourplan;
+
+// Freeze time for deterministic fixture hashes (SCUqty depends on moment())
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-02-17T00:00:00.000Z'));
+});
+afterAll(() => {
+  jest.useRealTimers();
+});
 
 describe('search tests', () => {
   afterEach(() => {

--- a/itinerary-add-service.js
+++ b/itinerary-add-service.js
@@ -169,7 +169,7 @@ const addServiceToItinerary = async ({
         if (Number.isNaN(num) || num < 1) return 1;
         return num;
       })(),
-      AgentRef: reference,
+      AgentRef: escapeInvalidXmlChars(reference),
       RoomConfigs: getRoomConfigs(paxConfigs),
       ...(directLinePayload || {}),
       ...(cfvPerService || {}),

--- a/jest.timezone.js
+++ b/jest.timezone.js
@@ -1,0 +1,6 @@
+/**
+ * Force UTC timezone for tests so fixture hashes are consistent across
+ * environments (Docker/CI typically use UTC; local dev may use a different TZ).
+ * Must run before any code that uses moment() or Date.
+ */
+process.env.TZ = 'UTC';

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "coveragePathIgnorePatterns": [
       "/node_modules/"
     ],
+		"setupFiles": [
+        "./jest.timezone.js"
+    ],
     "setupFilesAfterEnv": [
       "./jest.setup.js"
     ],


### PR DESCRIPTION
Also make 1st round of changes to make the test deterministic and reliable across environments
- Add Jest fake timers to stabilize fixture hashes (SCUqty/DateFrom use moment())
- Force UTC timezone via jest.timezone.js and TZ=UTC in test script
- Add TZ: UTC to CI workflow for consistent runs in Docker/CI
- Add missing fixtures for AgentInfoRequest and OptionInfoRequest tests
- Remove 18 unused non-UTC duplicate fixtures

Fixes failing tests caused by timezone differences between local dev and Docker/CI. Fixture hashes are now consistent across environments.