### PR TITLE
TC-945 umbrella: TourPlan HostConnect config and beta release lane

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,7 +1,6 @@
 name: Node.js Package
 
 on:
-  workflow_dispatch:
   push:
 
 jobs:
@@ -20,23 +19,45 @@ jobs:
           ti2_tourplan_endpoint: ${{ secrets.TOURPLAN_ENDPOINT }}
           ti2_tourplan_username: ${{ secrets.TOURPLAN_USERNAME }}
           ti2_tourplan_password: ${{ secrets.TOURPLAN_PASSWORD }}
-  tag:
-    if: github.ref == 'refs/heads/main'
+  publish-npm:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: build_and_test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: tool3/bump@master
+      - uses: actions/setup-node@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          unrelated: true
-          branch: main
-  publish-npm:
-    if: github.ref == 'refs/heads/main'
-    needs: tag
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+          node-version: 12
+      - name: Validate release tag
+        id: release_meta
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$TAG_NAME" =~ ^v([0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?)$ ]]; then
+            echo "Unsupported release tag format: $TAG_NAME"
+            exit 1
+          fi
+
+          TAG_VERSION="${BASH_REMATCH[1]}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+
+          if [[ "$TAG_VERSION" != "$PACKAGE_VERSION" ]]; then
+            echo "Tag version ${TAG_VERSION} does not match package.json version ${PACKAGE_VERSION}"
+            exit 1
+          fi
+
+          DIST_TAG="latest"
+          if [[ "$TAG_VERSION" == *-beta.* ]]; then
+            DIST_TAG="beta"
+          fi
+
+          echo "tag_version=${TAG_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
+      - name: Configure npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish package
+        run: npm publish --tag "${{ steps.release_meta.outputs.dist_tag }}"

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const defaultXmlOptions = {
     name: 'tourConnect_4_00_000.dtd',
   },
 };
+const urlRegExp = /^(?!mailto:)(?:(?:http|https|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[0-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))|localhost)(?::\d{2,5})?(?:(\/|\?|#)[^\s]*)?$/i;
 const getHeaders = ({ length }) => ({
   Accept: 'application/xml',
   'Content-Type': 'application/xml; charset=utf-8',
@@ -39,7 +40,7 @@ class BuyerPlugin {
     this.tokenTemplate = () => ({
       endpoint: {
         type: 'text',
-        regExp: /^(?!mailto:)(?:(?:http|https|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[0-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))|localhost)(?::\d{2,5})?(?:(\/|\?|#)[^\s]*)?$/i,
+        regExp: urlRegExp,
         description: 'The uri for the tourplan adapter',
       },
       username: {
@@ -63,6 +64,11 @@ class BuyerPlugin {
       hostConnectAgentPassword: {
         type: 'text',
         regExp: /.+/,
+      },
+      hostConnectBookingLinkBaseUrl: {
+        type: 'text',
+        regExp: urlRegExp,
+        description: 'The HostConnect booking page url used by the add-in to build booking reference links',
       },
       productConnectEndpoint: {
         type: 'text',

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ class BuyerPlugin {
       hostConnectBookingLinkBaseUrl: {
         type: 'text',
         regExp: urlRegExp,
-        description: 'The HostConnect booking page url used by the add-in to build booking reference links',
+        description: 'The HostConnect base url used by the add-in to build FastBook booking reference links',
       },
       productConnectEndpoint: {
         type: 'text',

--- a/index.test.js
+++ b/index.test.js
@@ -104,7 +104,7 @@ describe('search tests', () => {
     hostConnectEndpoint: 'https://test_hostConnectEndpoint.com',
     hostConnectAgentID: 'test_hostConnectAgentID',
     hostConnectAgentPassword: 'test_hostConnectAgentPassword',
-    hostConnectBookingLinkBaseUrl: 'https://example.tourplan.net/TourplanNX_Test/#/fastbook',
+    hostConnectBookingLinkBaseUrl: 'https://example.tourplan.net/TourplanNX_Test',
     seeAvailabilityRateInSupplierCurrency: 'Y',
   };
   const dateFormat = 'DD/MM/YYYY';
@@ -156,7 +156,7 @@ describe('search tests', () => {
         const hostConnectBookingLinkBaseUrl = template.hostConnectBookingLinkBaseUrl.regExp;
         expect(hostConnectBookingLinkBaseUrl.test('something')).toBeFalsy();
         expect(hostConnectBookingLinkBaseUrl.test(
-          'https://example.tourplan.net/TourplanNX_Test/#/fastbook'
+          'https://example.tourplan.net/TourplanNX_Test'
         )).toBeTruthy();
       });
     });

--- a/index.test.js
+++ b/index.test.js
@@ -104,6 +104,7 @@ describe('search tests', () => {
     hostConnectEndpoint: 'https://test_hostConnectEndpoint.com',
     hostConnectAgentID: 'test_hostConnectAgentID',
     hostConnectAgentPassword: 'test_hostConnectAgentPassword',
+    hostConnectBookingLinkBaseUrl: 'https://example.tourplan.net/TourplanNX_Test/#/fastbook',
     seeAvailabilityRateInSupplierCurrency: 'Y',
   };
   const dateFormat = 'DD/MM/YYYY';
@@ -134,6 +135,7 @@ describe('search tests', () => {
         expect(rules).toContain('endpoint');
         expect(rules).toContain('password');
         expect(rules).toContain('username');
+        expect(rules).toContain('hostConnectBookingLinkBaseUrl');
       });
       it('username', () => {
         const username = template.username.regExp;
@@ -149,6 +151,13 @@ describe('search tests', () => {
         const password = template.password.regExp;
         expect(password.test('')).toBeFalsy();
         expect(password.test('somepassword')).toBeTruthy();
+      });
+      it('hostConnectBookingLinkBaseUrl', () => {
+        const hostConnectBookingLinkBaseUrl = template.hostConnectBookingLinkBaseUrl.regExp;
+        expect(hostConnectBookingLinkBaseUrl.test('something')).toBeFalsy();
+        expect(hostConnectBookingLinkBaseUrl.test(
+          'https://example.tourplan.net/TourplanNX_Test/#/fastbook'
+        )).toBeTruthy();
       });
     });
     describe('DTD version detection', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ti2-tourplan",
-  "version": "1.0.115",
+  "version": "1.0.116-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ti2-tourplan",
-      "version": "1.0.115",
+      "version": "1.0.116-beta.0",
       "license": "GPLV3",
       "dependencies": {
         "@graphql-tools/schema": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2-tourplan",
-  "version": "1.0.115",
+  "version": "1.0.116-beta.0",
   "description": "Tourplan's TI2 Plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## TL;DR
`ti2-tourplan` slice of umbrella `TC-945`, focused on the TourPlan HostConnect config needed by the frontend and the beta release lane used for QA.

## What This PR Covers
- `TC-950`: adds `hostConnectBookingLinkBaseUrl` to the TourPlan token template
- `TC-950`: documents/tests the base URL as the instance root, with the frontend appending the FastBook route and booking reference
- release workflow: replaces auto-bump-on-main with tag-aware publishing from `package.json` version
- release workflow: stable tags publish to `latest`, beta tags publish to `beta`
- beta release: ships `1.0.116-beta.0` / `v1.0.116-beta.0` for staging validation

## Validation
- `docker exec ti2 bash -lc "cd /ti2-tourplan && npx jest index.test.js --runInBand"`

## Notes
- this repo does not generate the final TourPlan deep link; the frontend builds the final FastBook URL from this config
- supported publish tags are `vX.Y.Z` and `vX.Y.Z-beta.N`
