### PR TITLE
TC-943 (hotfix): Skip date range validation for packages & non-accommodation products

### DIFF
--- a/availability/itinerary-availability-helper.js
+++ b/availability/itinerary-availability-helper.js
@@ -1034,6 +1034,7 @@ const getAvailabilityConfig = async ({
     endDate,
     message,
     dateRanges,
+    duration,
     maxPaxPerCharge,
   };
 };

--- a/availability/itinerary-availability.js
+++ b/availability/itinerary-availability.js
@@ -119,6 +119,7 @@ const searchAvailabilityForItinerary = async ({
       Defaults to 1.
     */
     chargeUnitQuantity,
+    roomTypeRequired = true,
   },
   callTourplan,
   cache,
@@ -206,7 +207,19 @@ const searchAvailabilityForItinerary = async ({
     message,
     dateRanges,
     maxPaxPerCharge,
+    duration,
   } = availabilityConfig;
+
+  let isDateRangeValidationRequired = true;
+  // Skip date range validation for packages & non-accomodation products
+  // This is required because:
+  // 1. non-accomodation products that are not packages do not have date ranges
+  // and can be booked even on the last date of valid date range
+  // 2. packages (including multi-day packages) are allowed to be booked even on
+  // the last date of valid date range. (A package is when duration is > 1).
+  if ((duration && duration > 1) || !roomTypeRequired) {
+    isDateRangeValidationRequired = false;
+  }
 
   // Validate max pax per charge
   const maxPaxPerChargeError = validateMaxPaxPerCharge({
@@ -218,9 +231,9 @@ const searchAvailabilityForItinerary = async ({
   }
 
   let noOfDaysRatesAvailable = 0;
-  let allDatesHaveRatesAvailable = false;
 
   if (dateRanges.length > 0) {
+    let allDatesHaveRatesAvailable = true;
     const startDateIsInvalid = validateStartDay({
       dateRanges,
       startDate,
@@ -237,20 +250,24 @@ const searchAvailabilityForItinerary = async ({
 
     const lastDateRangeEndDate = moment(dateRanges[dateRanges.length - 1].endDate);
     noOfDaysRatesAvailable = lastDateRangeEndDate.diff(moment(startDate), 'days') + 1;
-    // eslint-disable-next-line max-len
-    allDatesHaveRatesAvailable = doAllDatesHaveRatesAvailable(lastDateRangeEndDate, startDate, chargeUnitQuantity);
+    if (isDateRangeValidationRequired) {
+      // eslint-disable-next-line max-len
+      allDatesHaveRatesAvailable = doAllDatesHaveRatesAvailable(lastDateRangeEndDate, startDate, chargeUnitQuantity);
+    }
 
     if (allDatesHaveRatesAvailable) {
       // all dates have rates available, get stay rates for the given dates
       // Validate date ranges and room configurations
-      const dateRangesError = validateDateRanges({
-        dateRanges,
-        startDate,
-        chargeUnitQuantity,
-      });
+      if (isDateRangeValidationRequired) {
+        const dateRangesError = validateDateRanges({
+          dateRanges,
+          startDate,
+          chargeUnitQuantity,
+        });
 
-      if (dateRangesError) {
-        return dateRangesError;
+        if (dateRangesError) {
+          return dateRangesError;
+        }
       }
 
       // get stay rates for the given dates
@@ -353,13 +370,16 @@ const searchAvailabilityForItinerary = async ({
   const customPeriodInfoMsg = useLastYearRate ? CUSTOM_PERIOD_LAST_YEAR_INFO_MSG : CUSTOM_PERIOD_LAST_AVAILABLE_INFO_MSG;
 
   let sWarningMsg = '';
+  let dateRangesError = null;
 
-  // Validate date ranges
-  const dateRangesError = validateDateRanges({
-    dateRanges: [dateRangeToUse],
-    startDate: dateRangeToUse.startDate,
-    chargeUnitQuantity,
-  });
+  if (isDateRangeValidationRequired) {
+    // Validate date ranges
+    dateRangesError = validateDateRanges({
+      dateRanges: [dateRangeToUse],
+      startDate: dateRangeToUse.startDate,
+      chargeUnitQuantity,
+    });
+  }
 
   let minStayRequired = 0;
   if (dateRangesError) {

--- a/availability/itinerary-availability.validation-flags.test.js
+++ b/availability/itinerary-availability.validation-flags.test.js
@@ -1,0 +1,149 @@
+/* globals describe, it, expect, jest, beforeEach */
+
+jest.mock('./itinerary-availability-utils', () => ({
+  validateMaxPaxPerCharge: jest.fn(() => null),
+  validateDateRanges: jest.fn(() => null),
+  validateStartDay: jest.fn(() => null),
+  getMatchingRateSet: jest.fn(() => ({ matchingRateSet: null })),
+}));
+
+jest.mock('./product-connect/itinerary-pc-api-validation-helper', () => ({
+  validateProductConnect: jest.fn(async () => false),
+}));
+
+jest.mock('./itinerary-availability-helper', () => ({
+  getAgentCurrencyCode: jest.fn(async () => 'USD'),
+  getConversionRate: jest.fn(async () => ({ conversionRate: 1 })),
+  findNextValidDate: jest.fn(() => null),
+  getAvailabilityConfig: jest.fn(async () => ({
+    roomConfigs: [{ Adults: 2 }],
+    endDate: null,
+    message: null,
+    dateRanges: [{ startDate: '2025-04-01', endDate: '2025-04-30', rateSets: [] }],
+    duration: null,
+    maxPaxPerCharge: null,
+  })),
+  getNoRatesAvailableError: jest.fn(async () => 'No rates available'),
+  getStayResults: jest.fn(async () => ([{
+    RateId: 'R1',
+    Currency: 'USD',
+    TotalPrice: '10000',
+    AgentPrice: '9000',
+  }])),
+  getCustomRateDateRange: jest.fn(async () => ({ dateRangeToUse: null, errorMsg: 'No custom rate' })),
+  getRatesObjectArray: jest.fn(() => ([{ rateId: 'R1', totalPrice: 10000, agentPrice: 9000 }])),
+  getEmptyRateObject: jest.fn(() => ([{ rateId: 'EMPTY' }])),
+  MIN_MARKUP_PERCENTAGE: 0,
+  MAX_MARKUP_PERCENTAGE: 100,
+  MIN_EXTENDED_BOOKING_YEARS: 1,
+  MAX_EXTENDED_BOOKING_YEARS: 10,
+  GENERIC_AVALABILITY_CHK_ERROR_MESSAGE: 'Generic availability error',
+}));
+
+jest.mock('./product-connect/itinerary-pc-rates-helper', () => ({
+  getCostFromProductConnect: jest.fn(async () => ({
+    success: false,
+    costPriceIncludingTax: 0,
+    taxRate: 0,
+  })),
+}));
+
+jest.mock('./product-connect/itinerary-pc-option-helper', () => ({
+  getOptionFromProductConnect: jest.fn(async () => null),
+  CROSS_SEASON_NOT_ALLOWED: 'N',
+  CROSS_SEASON_CAL_SPLIT_RATE: 'S',
+  CROSS_SEASON_CAL_USING_RATE_OF_FIRST_RATE_PERIOD: 'F',
+}));
+
+const itineraryAvailabilityUtils = require('./itinerary-availability-utils');
+const itineraryAvailabilityHelper = require('./itinerary-availability-helper');
+const { searchAvailabilityForItinerary } = require('./itinerary-availability');
+
+describe('searchAvailabilityForItinerary validation flags', () => {
+  const baseToken = {
+    hostConnectEndpoint: 'https://test-host-connect.com',
+    hostConnectAgentID: 'test-agent-id',
+    hostConnectAgentPassword: 'test-agent-password',
+  };
+
+  const basePayload = {
+    optionId: 'OPTION_1',
+    startDate: '2025-04-01',
+    chargeUnitQuantity: 2,
+    paxConfigs: [{ roomType: 'DB', adults: 2 }],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('runs date range validation when duration is not fixed and room type is required', async () => {
+    itineraryAvailabilityHelper.getAvailabilityConfig.mockResolvedValueOnce({
+      roomConfigs: [{ Adults: 2 }],
+      endDate: null,
+      message: null,
+      dateRanges: [{ startDate: '2025-04-01', endDate: '2025-04-30', rateSets: [] }],
+      duration: null,
+      maxPaxPerCharge: null,
+    });
+
+    const result = await searchAvailabilityForItinerary({
+      axios: jest.fn(),
+      token: baseToken,
+      payload: basePayload,
+      callTourplan: jest.fn(),
+      cache: { getOrExec: async ({ fn, fnParams }) => fn(...fnParams) },
+    });
+
+    expect(itineraryAvailabilityUtils.validateDateRanges).toHaveBeenCalled();
+    expect(result.bookable).toBe(true);
+    expect(result.type).toBe('inventory');
+  });
+
+  it('skips date range validation when roomTypeRequired is false', async () => {
+    itineraryAvailabilityHelper.getAvailabilityConfig.mockResolvedValueOnce({
+      roomConfigs: [{ Adults: 2 }],
+      endDate: null,
+      message: null,
+      dateRanges: [{ startDate: '2025-04-01', endDate: '2025-04-30', rateSets: [] }],
+      duration: null,
+      maxPaxPerCharge: null,
+    });
+
+    const result = await searchAvailabilityForItinerary({
+      axios: jest.fn(),
+      token: baseToken,
+      payload: { ...basePayload, roomTypeRequired: false },
+      callTourplan: jest.fn(),
+      cache: { getOrExec: async ({ fn, fnParams }) => fn(...fnParams) },
+    });
+
+    expect(itineraryAvailabilityUtils.validateDateRanges).not.toHaveBeenCalled();
+    expect(result.bookable).toBe(true);
+    expect(result.type).toBe('inventory');
+  });
+
+  it('skips date range validation when duration is greater than 1', async () => {
+    itineraryAvailabilityHelper.getAvailabilityConfig.mockResolvedValueOnce({
+      roomConfigs: [{ Adults: 2 }],
+      endDate: '2025-04-02',
+      message: 'Duration is fixed',
+      dateRanges: [{ startDate: '2025-04-01', endDate: '2025-04-30', rateSets: [] }],
+      duration: 2,
+      maxPaxPerCharge: null,
+    });
+
+    const result = await searchAvailabilityForItinerary({
+      axios: jest.fn(),
+      token: baseToken,
+      payload: basePayload,
+      callTourplan: jest.fn(),
+      cache: { getOrExec: async ({ fn, fnParams }) => fn(...fnParams) },
+    });
+
+    expect(itineraryAvailabilityUtils.validateDateRanges).not.toHaveBeenCalled();
+    expect(result.bookable).toBe(true);
+    expect(result.type).toBe('inventory');
+    expect(result.endDate).toBe('2025-04-02');
+  });
+});

--- a/index.test.js
+++ b/index.test.js
@@ -442,6 +442,27 @@ describe('search tests', () => {
       expect(retVal.type).toBe('inventory');
     });
 
+    it('searchAvailabilityForItinerary - default roomTypeRequired matches explicit true', async () => {
+      axios.mockImplementation(getFixture);
+      const payload = {
+        optionId: 'AKLACAKLSOFDYNAMC',
+        startDate: '2025-04-01',
+        chargeUnitQuantity: 2,
+        paxConfigs: [{ roomType: 'DB', adults: 1 }],
+      };
+      const defaultBehaviourResponse = await app.searchAvailabilityForItinerary({
+        axios,
+        token,
+        payload,
+      });
+      const explicitTrueResponse = await app.searchAvailabilityForItinerary({
+        axios,
+        token,
+        payload: { ...payload, roomTypeRequired: true },
+      });
+      expect(defaultBehaviourResponse).toEqual(explicitTrueResponse);
+    });
+
     // Skip this test because we aren't using A check anymore
     it.skip('searchAvailabilityForItinerary - bookable - on request', async () => {
       axios.mockImplementation(getFixture);

--- a/resolvers/product.js
+++ b/resolvers/product.js
@@ -25,7 +25,8 @@ const resolvers = {
       const lastUpdateISO = R.path(['OptGeneral', 'LastUpdate'], option);
       return lastUpdateISO ? new Date(lastUpdateISO).getTime() / 1000 : null;
     },
-    // Guides, Accommodation, Transfers, Entrance Fees, Meals, Rail, Sightseeing Other
+    // Guides, Accommodation, Transfers, Entrance Fees, Meals, Rail, Sightseeing,
+    // Rental Cars, Apartments, Blank Web Services, Farm Stays, Packages
     serviceType: option => {
       const st = R.pathOr('', ['OptGeneral', 'ButtonName'], option);
       return typeof st === 'string' ? st : '';


### PR DESCRIPTION
This is required because:
1. non-accomodation products that are not packages do not have date ranges and can be booked even on the last date of valid date range
2. packages (including multi-day packages) are allowed to be booked even on the last date of valid date range. (A package is when duration is > 1)

NOTE: Check [TC-943](https://tourconnect.atlassian.net/browse/TC-943) for examples

[TC-943]: https://tourconnect.atlassian.net/browse/TC-943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ