### PR TITLE
fix escapeInvalidXmlChars to replace every occurrence of mapped accented characters

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -55,7 +55,7 @@ const escapeInvalidXmlChars = str => {
       ['æ', 'ae'],
       ['ß', 'ss'],
     ];
-    const preprocessed = accentedChars.reduce((acc, [k, v]) => acc.replace(k, v), s);
+    const preprocessed = accentedChars.reduce((acc, [k, v]) => acc.split(k).join(v), s);
     return preprocessed.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
   };
   // NOTE: There is no need to sanitize the string for 5 characters (&, <, >, " and ')

--- a/utils.test.js
+++ b/utils.test.js
@@ -1,0 +1,32 @@
+const { escapeInvalidXmlChars } = require('./utils');
+
+describe('escapeInvalidXmlChars', () => {
+  it('returns empty string for falsy input', () => {
+    expect(escapeInvalidXmlChars('')).toBe('');
+    expect(escapeInvalidXmlChars(null)).toBe('');
+    expect(escapeInvalidXmlChars(undefined)).toBe('');
+  });
+
+  it('maps accented letters before NFD stripping', () => {
+    expect(escapeInvalidXmlChars('Müller')).toBe('Mueller');
+    expect(escapeInvalidXmlChars('Straße')).toBe('Strasse');
+    expect(escapeInvalidXmlChars('Søren')).toBe('Soeren');
+  });
+
+  it('maps repeated accented letters for every occurrence', () => {
+    expect(escapeInvalidXmlChars('öffnen und rösten')).toBe('oeffnen und roesten');
+    expect(escapeInvalidXmlChars('für süße Grüße')).toBe('fuer suesse Gruesse');
+  });
+
+  it('replaces smart quotes and en dash', () => {
+    expect(escapeInvalidXmlChars('Say ‘hi’ and “bye” – ok')).toBe('Say \'hi\' and "bye" - ok');
+  });
+
+  it('strips disallowed control characters', () => {
+    expect(escapeInvalidXmlChars('A\u0000B\u0008C')).toBe('ABC');
+  });
+
+  it('strips lone UTF-16 surrogate code units', () => {
+    expect(escapeInvalidXmlChars('X\uD800Y')).toBe('XY');
+  });
+});


### PR DESCRIPTION
Use split/join instead of String.replace which only matched the first hit; add regression test for repeated characters.