### PR TITLE
[TC-1014] hotfix: normalize non-breaking spaces in XML sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2-tourplan",
-  "version": "1.0.120",
+  "version": "1.0.121",
   "description": "Tourplan's TI2 Plugin",
   "main": "index.js",
   "scripts": {

--- a/utils.js
+++ b/utils.js
@@ -62,6 +62,7 @@ const escapeInvalidXmlChars = str => {
   // because js2xmlparser does that for us. Plus if we use sanitize before calling js2xmlparser
   // js2xmlparser will escape & to '&amp;' making it invalid XML
   return convertAccentedChars(asString)
+    .replace(/\u00A0/g, ' ')
     .replace(/’/g, "'")
     .replace(/‘/g, "'")
     .replace(/“/g, '"')

--- a/utils.test.js
+++ b/utils.test.js
@@ -22,6 +22,10 @@ describe('escapeInvalidXmlChars', () => {
     expect(escapeInvalidXmlChars('Say ‘hi’ and “bye” – ok')).toBe('Say \'hi\' and "bye" - ok');
   });
 
+  it('replaces non-breaking spaces with regular spaces', () => {
+    expect(escapeInvalidXmlChars('Borwieck\u00A0Mrs R')).toBe('Borwieck Mrs R');
+  });
+
   it('strips disallowed control characters', () => {
     expect(escapeInvalidXmlChars('A\u0000B\u0008C')).toBe('ABC');
   });


### PR DESCRIPTION
Replace \u00A0 with regular spaces in escapeInvalidXmlChars instead of stripping it