### PR TITLE
[TC-1297] BCM : add availability-only AD flow with consistent response and coverage

### DIFF
--- a/availability/itinerary-availability-helper.js
+++ b/availability/itinerary-availability-helper.js
@@ -140,6 +140,54 @@ const getDaysInYear = dateString => {
   const year = moment(dateString).year();
   return moment([year]).isLeapYear() ? 366 : 365;
 };
+
+/*
+  Option Availability Integer List (OptAvail)
+  This is a list of integers that represent the availability of the option for
+  each day in the requested date range.
+  The integers are to be interpreted as follows:
+  Greater than 0 means that inventory is available, with the integer specifying
+  the number of units available.
+  For options with a service type of Y , the inventory is in units of rooms.
+  For other service types, the inventory is in units of pax.
+  -1 Not available.
+  -2 Available on free sell.
+  -3 Available on request.
+  Note: A return value of 0 or something less than -3 is impossible.
+*/
+const getAvailabilityOnly = async ({
+  optionId,
+  hostConnectEndpoint,
+  hostConnectAgentID,
+  hostConnectAgentPassword,
+  axios,
+  startDate,
+  requestedEndDate,
+  callTourplan,
+}) => {
+  const isValidRequestedEndDate = moment(requestedEndDate, 'YYYY-MM-DD', true).isValid();
+  const dateTo = isValidRequestedEndDate
+    ? requestedEndDate
+    : moment(startDate).add(1, 'year').subtract(1, 'day').format('YYYY-MM-DD');
+  const model = {
+    OptionInfoRequest: {
+      Opt: optionId,
+      Info: 'AD',
+      AgentID: hostConnectAgentID,
+      Password: hostConnectAgentPassword,
+      DateFrom: startDate,
+      DateTo: dateTo,
+      ACache: 'N',
+    },
+  };
+  const replyObj = await callTourplan({
+    model,
+    endpoint: hostConnectEndpoint,
+    axios,
+    xmlOptions: hostConnectXmlOptions,
+  });
+  return R.pathOr([], ['OptionInfoReply', 'Option', 'OptAvail'], replyObj);
+};
 /*
     Get general option information from Tourplan API.
 
@@ -1327,6 +1375,7 @@ const findNextValidDate = (startDate, dateRanges) => {
 
 module.exports = {
   getAgentCurrencyCode,
+  getAvailabilityOnly,
   getAvailabilityConfig,
   getNoRatesAvailableError,
   getStayResults,

--- a/availability/itinerary-availability.js
+++ b/availability/itinerary-availability.js
@@ -18,6 +18,7 @@ const {
 } = require('./itinerary-availability-helper');
 
 const {
+  getAvailabilityOnly,
   getAvailabilityConfig,
   getNoRatesAvailableError,
   getStayResults,
@@ -86,6 +87,28 @@ const returnEmptyRatesOrError = (allowSendingServicesWithoutARate, agentCurrency
   };
 };
 
+const getOptAvailValues = optAvail => {
+  if (Array.isArray(optAvail)) {
+    return optAvail
+      .map(value => Number(value))
+      .filter(value => !Number.isNaN(value));
+  }
+
+  if (typeof optAvail === 'string') {
+    return optAvail
+      .trim()
+      .split(/\s+/)
+      .map(value => Number(value))
+      .filter(value => !Number.isNaN(value));
+  }
+
+  return [];
+};
+
+const isOptAvailBookable = optAvailValues => (
+  optAvailValues.some(value => value > 0 || value === -2 || value === -3)
+);
+
 const searchAvailabilityForItinerary = async ({
   axios,
   token: {
@@ -108,6 +131,7 @@ const searchAvailabilityForItinerary = async ({
   payload: {
     optionId,
     startDate,
+    endDate: requestedEndDate,
     /*
     paxConfigs: [{ roomType: 'DB', adults: 2 }, { roomType: 'TW', children: 2 }]
     */
@@ -120,10 +144,38 @@ const searchAvailabilityForItinerary = async ({
     */
     chargeUnitQuantity,
     roomTypeRequired = true,
+    availabilityOnly = false,
   },
   callTourplan,
   cache,
 }) => {
+  const isAvailabilityOnly = availabilityOnly === true;
+
+  if (isAvailabilityOnly) {
+    const availabilityOnlyResponse = await getAvailabilityOnly({
+      optionId,
+      hostConnectEndpoint,
+      hostConnectAgentID,
+      hostConnectAgentPassword,
+      axios,
+      startDate,
+      requestedEndDate,
+      callTourplan,
+    });
+    const optAvailValues = getOptAvailValues(availabilityOnlyResponse);
+    const SCheckPass = isOptAvailBookable(optAvailValues);
+    return {
+      bookable: SCheckPass,
+      type: 'availability',
+      ...(requestedEndDate && SCheckPass ? { endDate: requestedEndDate } : {}),
+      message: SCheckPass
+        ? 'Availability checked successfully'
+        : 'No availability found for the requested range',
+      availability: optAvailValues,
+      rates: [],
+    };
+  }
+
   // Get agent currency code & cache it
   const agentCurrencyCode = await getAgentCurrencyCode({
     hostConnectEndpoint,
@@ -385,7 +437,11 @@ const searchAvailabilityForItinerary = async ({
   if (dateRangesError) {
     if (dateRangesError.message.includes('minimum stay')) {
       // If minimum stay error, return availability with a warning message
-      const { matchingRateSet } = getMatchingRateSet(dateRangeToUse.rateSets, dateRangeToUse.startDate, chargeUnitQuantity);
+      const { matchingRateSet } = getMatchingRateSet(
+        dateRangeToUse.rateSets,
+        dateRangeToUse.startDate,
+        chargeUnitQuantity,
+      );
       minStayRequired = matchingRateSet ? matchingRateSet.minSCU : 0;
       sWarningMsg = MIN_STAY_WARNING_MESSAGE.replace('{minSCU}', minStayRequired);
     } else if (dateRangesError.message.includes('rates are closed')) {

--- a/availability/itinerary-availability.validation-flags.test.js
+++ b/availability/itinerary-availability.validation-flags.test.js
@@ -24,6 +24,7 @@ jest.mock('./itinerary-availability-helper', () => ({
     maxPaxPerCharge: null,
   })),
   getNoRatesAvailableError: jest.fn(async () => 'No rates available'),
+  getAvailabilityOnly: jest.fn(async () => '-1 -1 -1'),
   getStayResults: jest.fn(async () => ([{
     RateId: 'R1',
     Currency: 'USD',
@@ -145,5 +146,45 @@ describe('searchAvailabilityForItinerary validation flags', () => {
     expect(result.bookable).toBe(true);
     expect(result.type).toBe('inventory');
     expect(result.endDate).toBe('2025-04-02');
+  });
+
+  it('uses availabilityOnly flow and keeps response shape consistent', async () => {
+    itineraryAvailabilityHelper.getAvailabilityOnly.mockResolvedValueOnce('-1 -2 -1');
+
+    const result = await searchAvailabilityForItinerary({
+      axios: jest.fn(),
+      token: baseToken,
+      payload: { ...basePayload, availabilityOnly: true, endDate: '2025-04-05' },
+      callTourplan: jest.fn(),
+      cache: { getOrExec: async ({ fn, fnParams }) => fn(...fnParams) },
+    });
+
+    expect(itineraryAvailabilityHelper.getAvailabilityOnly).toHaveBeenCalledTimes(1);
+    expect(itineraryAvailabilityHelper.getAgentCurrencyCode).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      bookable: true,
+      type: 'availability',
+      endDate: '2025-04-05',
+      message: 'Availability checked successfully',
+      availability: [-1, -2, -1],
+      rates: [],
+    });
+  });
+
+  it('marks availabilityOnly response as not bookable when all days are unavailable', async () => {
+    itineraryAvailabilityHelper.getAvailabilityOnly.mockResolvedValueOnce('-1 -1 -1');
+
+    const result = await searchAvailabilityForItinerary({
+      axios: jest.fn(),
+      token: baseToken,
+      payload: { ...basePayload, availabilityOnly: true, endDate: '2025-04-05' },
+      callTourplan: jest.fn(),
+      cache: { getOrExec: async ({ fn, fnParams }) => fn(...fnParams) },
+    });
+
+    expect(result.bookable).toBe(false);
+    expect(result.message).toBe('No availability found for the requested range');
+    expect(result.availability).toEqual([-1, -1, -1]);
+    expect(result.rates).toEqual([]);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2-tourplan",
-  "version": "1.0.121",
+  "version": "1.0.122",
   "description": "Tourplan's TI2 Plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- route availabilityOnly === true through OptionInfoRequest Info: AD and return parsed OptAvail
- compute bookable from OptAvail semantics (>0, -2, -3) and return availability payload shape consistently
- add focused validation tests for availability-only path and set test runner timezone to UTC for deterministic fixture hashing