### PR TITLE
feat: add cancelBooking via HostConnect CancelServicesRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,69 @@ TL;DR Here's what the license entails:
 7. Any modifications of this code base MUST be distributed with the same license, GPLv3.
 8. This software is provided without warranty.
 9. The software author or license can not be held liable for any damages inflicted by the software.
+
+## Cancel Booking (HostConnect)
+
+This plugin cancels bookings using `CancelServicesRequest` (not `CancelBookingRequest`).
+
+### HostConnect XML Request
+
+```xml
+<Request>
+  <CancelServicesRequest>
+    <AgentID>YOUR_AGENT_ID</AgentID>
+    <Password>YOUR_AGENT_PASSWORD</Password>
+    <BookingId>14226</BookingId>
+    <ReturnBooking>Y</ReturnBooking>
+  </CancelServicesRequest>
+</Request>
+```
+
+Equivalent curl:
+
+```bash
+curl --location 'https://<HOSTCONNECT_ENDPOINT>/api/hostConnectApi' \
+--header 'Content-Type: application/xml; charset=utf-8' \
+--header 'requestId: <uuid>' \
+--header 'Accept: application/xml' \
+--data '<Request>
+  <CancelServicesRequest>
+    <AgentID>YOUR_AGENT_ID</AgentID>
+    <Password>YOUR_AGENT_PASSWORD</Password>
+    <BookingId>14226</BookingId>
+    <ReturnBooking>Y</ReturnBooking>
+  </CancelServicesRequest>
+</Request>'
+```
+
+### HostConnect XML Response (example)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_05_010.dtd">
+<Reply>
+  <CancelServicesReply>
+    <BookingId>14226</BookingId>
+    <Ref>A2IN111975</Ref>
+    <ServiceStatuses>
+      <ServiceStatus>
+        <ServiceLineId>61738</ServiceLineId>
+        <Date>2026-07-03</Date>
+        <SequenceNumber>10</SequenceNumber>
+        <Status>XX</Status>
+      </ServiceStatus>
+    </ServiceStatuses>
+  </CancelServicesReply>
+</Reply>
+```
+
+### Plugin Return Shape
+
+The plugin returns both:
+
+- `cancelServicesReply`: raw parsed `CancelServicesReply` object
+- `cancellation`: normalized object
+  - `id`: from `BookingId`
+  - `status`: aggregate over all `ServiceStatus.Status` values:
+    - same status on all lines => that status (e.g. `XX`)
+    - mixed line statuses => `MIXED`

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const Normalizer = require('./normalizer');
 
 const { searchAvailabilityForItinerary } = require('./availability/itinerary-availability');
 const { addServiceToItinerary } = require('./itinerary-add-service');
+const { cancelBooking } = require('./itinerary-cancel-booking');
 const { searchProductsForItinerary } = require('./itinerary-products-search');
 const { searchItineraries } = require('./itinerary-search');
 const { hostConnectXmlOptions } = require('./utils');
@@ -672,6 +673,19 @@ class BuyerPlugin {
     payload,
   }) {
     return addServiceToItinerary({
+      axios,
+      token,
+      payload,
+      callTourplan: this.callTourplan.bind(this),
+    });
+  }
+
+  async cancelBooking({
+    axios,
+    token,
+    payload,
+  }) {
+    return cancelBooking({
       axios,
       token,
       payload,

--- a/index.test.js
+++ b/index.test.js
@@ -132,6 +132,149 @@ describe('search tests', () => {
         }
       });
     });
+    describe('cancelBooking', () => {
+      it('cancels a booking by id', async () => {
+        mockCallTourplan.mockImplementationOnce(async () => ({
+          CancelServicesReply: {
+            BookingId: '316559',
+            Ref: 'A2IN111975',
+            ServiceStatuses: {
+              ServiceStatus: {
+                ServiceLineId: '61738',
+                Date: '2026-07-03',
+                SequenceNumber: '10',
+                Status: 'XX',
+              },
+            },
+          },
+        }));
+        const retVal = await app.cancelBooking({
+          axios,
+          token,
+          payload: {
+            id: '316559',
+            status: 'Cancelled',
+            clicked: 1719571452,
+          },
+        });
+        expect(mockCallTourplan).toHaveBeenNthCalledWith(1, expect.objectContaining({
+          model: {
+            CancelServicesRequest: expect.objectContaining({
+              BookingId: '316559',
+              ReturnBooking: 'Y',
+            }),
+          },
+        }));
+        expect(retVal).toEqual({
+          cancelServicesReply: {
+            BookingId: '316559',
+            Ref: 'A2IN111975',
+            ServiceStatuses: {
+              ServiceStatus: {
+                ServiceLineId: '61738',
+                Date: '2026-07-03',
+                SequenceNumber: '10',
+                Status: 'XX',
+              },
+            },
+          },
+          cancellation: {
+            id: '316559',
+            status: 'XX',
+          },
+        });
+      });
+
+      it('cancels a booking by ref', async () => {
+        mockCallTourplan.mockImplementationOnce(async () => ({
+          CancelServicesReply: {
+            BookingId: '316559',
+            ServiceStatuses: {
+              ServiceStatus: [{
+                ServiceLineId: '61738',
+                Status: 'XX',
+              }],
+            },
+          },
+        }));
+        const retVal = await app.cancelBooking({
+          axios,
+          token,
+          payload: {
+            ref: 'ALFI393706',
+            status: 'Cancelled',
+            clicked: 1719571452,
+          },
+        });
+        expect(mockCallTourplan).toHaveBeenNthCalledWith(1, expect.objectContaining({
+          model: {
+            CancelServicesRequest: expect.objectContaining({
+              Ref: 'ALFI393706',
+              ReturnBooking: 'Y',
+            }),
+          },
+        }));
+        expect(retVal).toEqual({
+          cancelServicesReply: {
+            BookingId: '316559',
+            ServiceStatuses: {
+              ServiceStatus: [{
+                ServiceLineId: '61738',
+                Status: 'XX',
+              }],
+            },
+          },
+          cancellation: {
+            id: '316559',
+            status: 'XX',
+          },
+        });
+      });
+
+      it('returns MIXED status when service statuses differ', async () => {
+        mockCallTourplan.mockImplementationOnce(async () => ({
+          CancelServicesReply: {
+            BookingId: '316559',
+            ServiceStatuses: {
+              ServiceStatus: [{
+                ServiceLineId: '61738',
+                Status: 'XX',
+              }, {
+                ServiceLineId: '61739',
+                Status: 'RQ',
+              }],
+            },
+          },
+        }));
+        const retVal = await app.cancelBooking({
+          axios,
+          token,
+          payload: {
+            bookingId: '316559',
+            status: 'Cancelled',
+            clicked: 1719571452,
+          },
+        });
+        expect(retVal).toEqual({
+          cancelServicesReply: {
+            BookingId: '316559',
+            ServiceStatuses: {
+              ServiceStatus: [{
+                ServiceLineId: '61738',
+                Status: 'XX',
+              }, {
+                ServiceLineId: '61739',
+                Status: 'RQ',
+              }],
+            },
+          },
+          cancellation: {
+            id: '316559',
+            status: 'MIXED',
+          },
+        });
+      });
+    });
     describe('template tests', () => {
       let template;
       it('get the template', async () => {

--- a/itinerary-cancel-booking.js
+++ b/itinerary-cancel-booking.js
@@ -1,0 +1,110 @@
+const assert = require('assert');
+const R = require('ramda');
+const {
+  hostConnectXmlOptions,
+  escapeInvalidXmlChars,
+} = require('./utils');
+
+const getIdentifier = payload => {
+  const bookingId = payload.bookingId || payload.id;
+  if (bookingId) {
+    return {
+      field: 'BookingId',
+      value: String(bookingId),
+    };
+  }
+  const bookingRef = payload.ref || payload.reference;
+  if (bookingRef) {
+    return {
+      field: 'Ref',
+      value: escapeInvalidXmlChars(String(bookingRef)),
+    };
+  }
+  return null;
+};
+
+const extractCancellationReply = replyObj => (
+  R.path(['CancelServicesReply'], replyObj)
+  || {}
+);
+
+const getServiceStatusList = cancellationReply => {
+  let serviceStatuses = R.pathOr([], ['ServiceStatuses', 'ServiceStatus'], cancellationReply);
+  if (!Array.isArray(serviceStatuses)) serviceStatuses = [serviceStatuses];
+  return serviceStatuses
+    .map(serviceStatus => R.path(['Status'], serviceStatus))
+    .filter(Boolean)
+    .map(status => String(status).toUpperCase());
+};
+
+const getAggregateServiceStatus = cancellationReply => {
+  const statuses = getServiceStatusList(cancellationReply);
+  if (!statuses.length) return null;
+  const uniqueStatuses = [...new Set(statuses)];
+  if (uniqueStatuses.length === 1) return uniqueStatuses[0];
+  return 'MIXED';
+};
+
+const normalizeCancellationResponse = (replyObj, payload, identifier) => {
+  const cancellationReply = extractCancellationReply(replyObj);
+  const aggregateServiceStatus = getAggregateServiceStatus(cancellationReply);
+  return {
+    cancelServicesReply: cancellationReply,
+    cancellation: {
+      id: R.path(['BookingId'], cancellationReply) || identifier.value,
+      status: aggregateServiceStatus
+        || R.path(['BookingStatus'], cancellationReply)
+        || R.path(['Status'], cancellationReply)
+        || payload.status
+        || 'Cancelled',
+    },
+  };
+};
+
+/**
+ * Cancels a booking by id or reference
+ * @param {Object} params - The parameters for the cancellation
+ * @param {Object} params.axios - The axios instance
+ * @param {Object} params.token - The token for the cancellation
+ * @param {Object} params.payload - The payload for the cancellation
+ * @param {Object} params.callTourplan - The callTourplan function
+ * @returns {Promise<Object>} The cancellation response
+ */
+const cancelBooking = async ({
+  axios,
+  token: {
+    hostConnectEndpoint,
+    hostConnectAgentID,
+    hostConnectAgentPassword,
+  },
+  payload = {},
+  callTourplan,
+}) => {
+  assert(hostConnectEndpoint, 'Must provide token.hostConnectEndpoint for booking cancellation');
+  assert(hostConnectAgentID, 'Must provide token.hostConnectAgentID for booking cancellation');
+  assert(hostConnectAgentPassword, 'Must provide token.hostConnectAgentPassword for booking cancellation');
+  const identifier = getIdentifier(payload);
+  assert(identifier, 'Must provide booking id or reference for cancellation');
+
+  const baseRequest = {
+    AgentID: hostConnectAgentID,
+    Password: hostConnectAgentPassword,
+    [identifier.field]: identifier.value,
+  };
+  const replyObj = await callTourplan({
+    model: {
+      CancelServicesRequest: {
+        ...baseRequest,
+        ReturnBooking: 'Y',
+      },
+    },
+    endpoint: hostConnectEndpoint,
+    axios,
+    xmlOptions: hostConnectXmlOptions,
+  });
+  return normalizeCancellationResponse(replyObj, payload, identifier);
+};
+
+module.exports = {
+  cancelBooking,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2-tourplan",
-  "version": "1.0.122",
+  "version": "1.0.123",
   "description": "Tourplan's TI2 Plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Implements the ti2 `cancelBooking` plugin method for the Tourplan HostConnect integration. Cancellation is performed using the `CancelServicesRequest` API (not `CancelBookingRequest`, which does not exist in this version of HostConnect).

- Accepts `bookingId`, `id`, `ref`, or `reference` as booking identifier
- Sends `CancelServicesRequest` with `ReturnBooking: Y` to HostConnect
- Returns raw `cancelServicesReply` (full parsed `CancelServicesReply`) alongside a normalized `cancellation` object:
  - `id`: from `BookingId` in reply
  - `status`: aggregate across all `ServiceStatuses.ServiceStatus.Status` values — single uniform status (e.g. `XX`) or `MIXED` when lines differ
- Handles both object and array forms of `ServiceStatus` (fast-xml-parser returns an object for single elements, array for multiple)
- Validates all three required token fields with clear assert messages

- Imports `cancelBooking` from `itinerary-cancel-booking`
- Registers `cancelBooking` method on `BuyerPlugin`, following the same pattern as `addServiceToItinerary` and `searchItineraries`

- Cancel by numeric booking id, single ServiceStatus object → status `XX`
- Cancel by booking ref, single ServiceStatus array → status `XX`
- Cancel with multiple service lines returning mixed statuses → status `MIXED`

- Documents HostConnect XML request and response shapes with real example from live traffic (BookingId 14226, Ref A2IN111975)
- Documents equivalent curl command
- Documents plugin return contract including aggregate status logic

Request:
  CancelServicesRequest { AgentID, Password, BookingId, ReturnBooking: Y }

Response:
  CancelServicesReply { BookingId, Ref, ServiceStatuses.ServiceStatus[] { ServiceLineId, Date, SequenceNumber, Status } }

Cancelled service lines carry Status = XX.

- 3 new cancelBooking tests pass
- 0 regressions (19 pre-existing failures unchanged, 3 additional passes)