### PR TITLE
[TC-1319] feat: add confirmBooking (QuoteToBook) and refactor shared HostConnect helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,68 @@ The plugin returns both:
   - `status`: aggregate over all `ServiceStatus.Status` values:
     - same status on all lines => that status (e.g. `XX`)
     - mixed line statuses => `MIXED`
+
+## Confirm Booking (HostConnect)
+
+This plugin converts a quote to a confirmed booking using HostConnect `QuoteToBookRequest`. Inventory is allocated for each service line when the quote is confirmed; the returned `ServiceStatus` values indicate whether allocation succeeded per line.
+
+### HostConnect XML Request
+
+```xml
+<Request>
+  <QuoteToBookRequest>
+    <AgentID>YOUR_AGENT_ID</AgentID>
+    <Password>YOUR_AGENT_PASSWORD</Password>
+    <BookingId>14226</BookingId>
+  </QuoteToBookRequest>
+</Request>
+```
+
+Equivalent curl:
+
+```bash
+curl --location 'https://<HOSTCONNECT_ENDPOINT>/api/hostConnectApi' \
+--header 'Content-Type: application/xml; charset=utf-8' \
+--header 'requestId: <uuid>' \
+--header 'Accept: application/xml' \
+--data '<Request>
+  <QuoteToBookRequest>
+    <AgentID>YOUR_AGENT_ID</AgentID>
+    <Password>YOUR_AGENT_PASSWORD</Password>
+    <BookingId>14226</BookingId>
+  </QuoteToBookRequest>
+</Request>'
+```
+
+### HostConnect XML Response (example)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Reply SYSTEM "hostConnect_5_05_010.dtd">
+<Reply>
+  <QuoteToBookReply>
+    <BookingId>14226</BookingId>
+    <Ref>A2IN111975</Ref>
+    <ServiceStatuses>
+      <ServiceStatus>
+        <Ref>A2IN111975</Ref>
+        <ServiceLineId>61738</ServiceLineId>
+        <Date>2026-07-03</Date>
+        <SequenceNumber>10</SequenceNumber>
+        <Status>OK</Status>
+      </ServiceStatus>
+    </ServiceStatuses>
+  </QuoteToBookReply>
+</Reply>
+```
+
+### Plugin Return Shape
+
+The plugin returns both:
+
+- `confirmBookingReply`: raw parsed HostConnect `QuoteToBookReply` object
+- `booking`: normalized object
+  - `ref`: from `Ref`
+  - `id`: from `BookingId` (or the identifier sent in the request)
+  - `status`: aggregate over all `ServiceStatus.Status` values (same rules as cancel), with fallbacks to `BookingStatus`, `Status`, `payload.status`, then `'Confirmed'`
+  - `serviceLines`: array of `{ ref, serviceLineId, date, sequenceNumber, status }`

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const Normalizer = require('./normalizer');
 const { searchAvailabilityForItinerary } = require('./availability/itinerary-availability');
 const { addServiceToItinerary } = require('./itinerary-add-service');
 const { cancelBooking } = require('./itinerary-cancel-booking');
+const { confirmBooking } = require('./itinerary-confirm-booking');
 const { searchProductsForItinerary } = require('./itinerary-products-search');
 const { searchItineraries } = require('./itinerary-search');
 const { hostConnectXmlOptions } = require('./utils');
@@ -680,12 +681,31 @@ class BuyerPlugin {
     });
   }
 
+  /**
+   * Cancel a booking.
+   */
   async cancelBooking({
     axios,
     token,
     payload,
   }) {
     return cancelBooking({
+      axios,
+      token,
+      payload,
+      callTourplan: this.callTourplan.bind(this),
+    });
+  }
+
+  /**
+   * Convert a quote to a confirmed booking.
+   */
+  async confirmBooking({
+    axios,
+    token,
+    payload,
+  }) {
+    return confirmBooking({
       axios,
       token,
       payload,

--- a/index.test.js
+++ b/index.test.js
@@ -274,6 +274,163 @@ describe('search tests', () => {
           },
         });
       });
+
+      it('requires a booking id or reference', async () => {
+        await expect(app.cancelBooking({
+          axios,
+          token,
+          payload: {},
+        })).rejects.toThrow('Must provide booking id or reference for cancellation');
+        expect(mockCallTourplan).not.toHaveBeenCalled();
+      });
+    });
+    describe('confirmBooking', () => {
+      it('converts a quote to a booking by id', async () => {
+        mockCallTourplan.mockImplementationOnce(async () => ({
+          QuoteToBookReply: {
+            BookingId: '14226',
+            Ref: 'A2IN111975',
+            ServiceStatuses: {
+              ServiceStatus: {
+                Ref: 'A2IN111975',
+                ServiceLineId: '61738',
+                Date: '2026-07-03',
+                SequenceNumber: '10',
+                Status: 'OK',
+              },
+            },
+          },
+        }));
+        const retVal = await app.confirmBooking({
+          axios,
+          token,
+          payload: {
+            bookingId: '14226',
+          },
+        });
+        expect(mockCallTourplan).toHaveBeenNthCalledWith(1, expect.objectContaining({
+          model: {
+            QuoteToBookRequest: expect.objectContaining({
+              BookingId: '14226',
+            }),
+          },
+        }));
+        expect(retVal).toEqual({
+          confirmBookingReply: {
+            BookingId: '14226',
+            Ref: 'A2IN111975',
+            ServiceStatuses: {
+              ServiceStatus: {
+                Ref: 'A2IN111975',
+                ServiceLineId: '61738',
+                Date: '2026-07-03',
+                SequenceNumber: '10',
+                Status: 'OK',
+              },
+            },
+          },
+          booking: {
+            ref: 'A2IN111975',
+            id: '14226',
+            status: 'OK',
+            serviceLines: [{
+              ref: 'A2IN111975',
+              serviceLineId: '61738',
+              date: '2026-07-03',
+              sequenceNumber: '10',
+              status: 'OK',
+            }],
+          },
+        });
+      });
+
+      it('converts a quote to a booking by ref', async () => {
+        mockCallTourplan.mockImplementationOnce(async () => ({
+          QuoteToBookReply: {
+            BookingId: '14226',
+            Ref: 'A2IN111975',
+            ServiceStatuses: {
+              ServiceStatus: [{
+                ServiceLineId: '61738',
+                Date: '2026-07-03',
+                SequenceNumber: '10',
+                Status: 'OK',
+              }],
+            },
+          },
+        }));
+        const retVal = await app.confirmBooking({
+          axios,
+          token,
+          payload: {
+            ref: 'A2IN111975',
+          },
+        });
+        expect(mockCallTourplan).toHaveBeenNthCalledWith(1, expect.objectContaining({
+          model: {
+            QuoteToBookRequest: expect.objectContaining({
+              Ref: 'A2IN111975',
+            }),
+          },
+        }));
+        expect(retVal.booking.id).toBe('14226');
+        expect(retVal.booking.ref).toBe('A2IN111975');
+        expect(retVal.booking.status).toBe('OK');
+      });
+
+      it('returns MIXED status when service line statuses differ', async () => {
+        mockCallTourplan.mockImplementationOnce(async () => ({
+          QuoteToBookReply: {
+            BookingId: '14226',
+            Ref: 'A2IN111975',
+            ServiceStatuses: {
+              ServiceStatus: [{
+                ServiceLineId: '61738',
+                Status: 'OK',
+              }, {
+                ServiceLineId: '61739',
+                Status: 'RQ',
+              }],
+            },
+          },
+        }));
+        const retVal = await app.confirmBooking({
+          axios,
+          token,
+          payload: {
+            bookingId: '14226',
+          },
+        });
+        expect(retVal.booking.status).toBe('MIXED');
+        expect(retVal.booking.serviceLines).toHaveLength(2);
+      });
+
+      it('requires a booking id or reference', async () => {
+        await expect(app.confirmBooking({
+          axios,
+          token,
+          payload: {},
+        })).rejects.toThrow('Must provide booking id or reference for confirm booking');
+        expect(mockCallTourplan).not.toHaveBeenCalled();
+      });
+
+      it('falls back to Confirmed when no service statuses are returned', async () => {
+        mockCallTourplan.mockImplementationOnce(async () => ({
+          QuoteToBookReply: {
+            BookingId: '14226',
+            Ref: 'A2IN111975',
+          },
+        }));
+        const retVal = await app.confirmBooking({
+          axios,
+          token,
+          payload: {
+            bookingId: '14226',
+          },
+        });
+        expect(retVal.booking.status).toBe('Confirmed');
+        expect(retVal.booking.serviceLines).toEqual([]);
+      });
     });
     describe('template tests', () => {
       let template;

--- a/itinerary-cancel-booking.js
+++ b/itinerary-cancel-booking.js
@@ -2,48 +2,16 @@ const assert = require('assert');
 const R = require('ramda');
 const {
   hostConnectXmlOptions,
-  escapeInvalidXmlChars,
 } = require('./utils');
-
-const getIdentifier = payload => {
-  const bookingId = payload.bookingId || payload.id;
-  if (bookingId) {
-    return {
-      field: 'BookingId',
-      value: String(bookingId),
-    };
-  }
-  const bookingRef = payload.ref || payload.reference;
-  if (bookingRef) {
-    return {
-      field: 'Ref',
-      value: escapeInvalidXmlChars(String(bookingRef)),
-    };
-  }
-  return null;
-};
+const {
+  getBookingIdentifier,
+  getAggregateServiceStatus,
+} = require('./itinerary-hostconnect-helpers');
 
 const extractCancellationReply = replyObj => (
   R.path(['CancelServicesReply'], replyObj)
   || {}
 );
-
-const getServiceStatusList = cancellationReply => {
-  let serviceStatuses = R.pathOr([], ['ServiceStatuses', 'ServiceStatus'], cancellationReply);
-  if (!Array.isArray(serviceStatuses)) serviceStatuses = [serviceStatuses];
-  return serviceStatuses
-    .map(serviceStatus => R.path(['Status'], serviceStatus))
-    .filter(Boolean)
-    .map(status => String(status).toUpperCase());
-};
-
-const getAggregateServiceStatus = cancellationReply => {
-  const statuses = getServiceStatusList(cancellationReply);
-  if (!statuses.length) return null;
-  const uniqueStatuses = [...new Set(statuses)];
-  if (uniqueStatuses.length === 1) return uniqueStatuses[0];
-  return 'MIXED';
-};
 
 const normalizeCancellationResponse = (replyObj, payload, identifier) => {
   const cancellationReply = extractCancellationReply(replyObj);
@@ -62,13 +30,7 @@ const normalizeCancellationResponse = (replyObj, payload, identifier) => {
 };
 
 /**
- * Cancels a booking by id or reference
- * @param {Object} params - The parameters for the cancellation
- * @param {Object} params.axios - The axios instance
- * @param {Object} params.token - The token for the cancellation
- * @param {Object} params.payload - The payload for the cancellation
- * @param {Object} params.callTourplan - The callTourplan function
- * @returns {Promise<Object>} The cancellation response
+ * Cancels a booking by id or reference via HostConnect CancelServicesRequest.
  */
 const cancelBooking = async ({
   axios,
@@ -83,7 +45,7 @@ const cancelBooking = async ({
   assert(hostConnectEndpoint, 'Must provide token.hostConnectEndpoint for booking cancellation');
   assert(hostConnectAgentID, 'Must provide token.hostConnectAgentID for booking cancellation');
   assert(hostConnectAgentPassword, 'Must provide token.hostConnectAgentPassword for booking cancellation');
-  const identifier = getIdentifier(payload);
+  const identifier = getBookingIdentifier(payload);
   assert(identifier, 'Must provide booking id or reference for cancellation');
 
   const baseRequest = {

--- a/itinerary-confirm-booking.js
+++ b/itinerary-confirm-booking.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const R = require('ramda');
+const { hostConnectXmlOptions } = require('./utils');
+const {
+  getBookingIdentifier,
+  getAggregateServiceStatus,
+  mapServiceStatusLines,
+} = require('./itinerary-hostconnect-helpers');
+
+const extractConfirmBookingReply = replyObj => (
+  R.path(['QuoteToBookReply'], replyObj)
+  || {}
+);
+
+const normalizeConfirmBookingResponse = (replyObj, payload, identifier) => {
+  const confirmBookingReply = extractConfirmBookingReply(replyObj);
+  const aggregateServiceStatus = getAggregateServiceStatus(confirmBookingReply);
+  return {
+    confirmBookingReply,
+    booking: {
+      ref: R.path(['Ref'], confirmBookingReply),
+      id: R.path(['BookingId'], confirmBookingReply) || identifier.value,
+      status: aggregateServiceStatus
+        || R.path(['BookingStatus'], confirmBookingReply)
+        || R.path(['Status'], confirmBookingReply)
+        || payload.status
+        || 'Confirmed',
+      serviceLines: mapServiceStatusLines(confirmBookingReply),
+    },
+  };
+};
+
+/**
+ * Converts a quote to a confirmed booking via HostConnect QuoteToBookRequest.
+ * Inventory is allocated for each service line; returned ServiceStatus values
+ * indicate whether allocation succeeded per line.
+ */
+const confirmBooking = async ({
+  axios,
+  token: {
+    hostConnectEndpoint,
+    hostConnectAgentID,
+    hostConnectAgentPassword,
+  },
+  payload = {},
+  callTourplan,
+}) => {
+  assert(hostConnectEndpoint, 'Must provide token.hostConnectEndpoint for confirm booking');
+  assert(hostConnectAgentID, 'Must provide token.hostConnectAgentID for confirm booking');
+  assert(hostConnectAgentPassword, 'Must provide token.hostConnectAgentPassword for confirm booking');
+  const identifier = getBookingIdentifier(payload);
+  assert(identifier, 'Must provide booking id or reference for confirm booking');
+
+  const baseRequest = {
+    AgentID: hostConnectAgentID,
+    Password: hostConnectAgentPassword,
+    [identifier.field]: identifier.value,
+  };
+  const replyObj = await callTourplan({
+    model: {
+      QuoteToBookRequest: baseRequest,
+    },
+    endpoint: hostConnectEndpoint,
+    axios,
+    xmlOptions: hostConnectXmlOptions,
+  });
+  return normalizeConfirmBookingResponse(replyObj, payload, identifier);
+};
+
+module.exports = {
+  confirmBooking,
+};

--- a/itinerary-hostconnect-helpers.js
+++ b/itinerary-hostconnect-helpers.js
@@ -1,0 +1,52 @@
+const R = require('ramda');
+const { escapeInvalidXmlChars } = require('./utils');
+
+const getBookingIdentifier = payload => {
+  const bookingId = payload.bookingId || payload.id;
+  if (bookingId) {
+    return {
+      field: 'BookingId',
+      value: String(bookingId),
+    };
+  }
+  const bookingRef = payload.ref || payload.reference;
+  if (bookingRef) {
+    return {
+      field: 'Ref',
+      value: escapeInvalidXmlChars(String(bookingRef)),
+    };
+  }
+  return null;
+};
+
+const toServiceStatusArray = reply => {
+  let serviceStatuses = R.pathOr([], ['ServiceStatuses', 'ServiceStatus'], reply);
+  if (!Array.isArray(serviceStatuses)) serviceStatuses = [serviceStatuses];
+  return serviceStatuses.filter(Boolean);
+};
+
+const getAggregateServiceStatus = reply => {
+  const statuses = toServiceStatusArray(reply)
+    .map(serviceStatus => R.path(['Status'], serviceStatus))
+    .filter(Boolean)
+    .map(status => String(status).toUpperCase());
+  if (!statuses.length) return null;
+  const uniqueStatuses = [...new Set(statuses)];
+  if (uniqueStatuses.length === 1) return uniqueStatuses[0];
+  return 'MIXED';
+};
+
+const mapServiceStatusLines = reply => toServiceStatusArray(reply).map(serviceStatus => ({
+  ref: R.path(['Ref'], serviceStatus),
+  serviceLineId: R.path(['ServiceLineId'], serviceStatus),
+  date: R.path(['Date'], serviceStatus),
+  sequenceNumber: R.path(['SequenceNumber'], serviceStatus),
+  status: R.path(['Status'], serviceStatus),
+}));
+
+module.exports = {
+  getBookingIdentifier,
+  toServiceStatusArray,
+  getAggregateServiceStatus,
+  mapServiceStatusLines,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ti2-tourplan",
-  "version": "1.0.117",
+  "version": "1.0.124",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ti2-tourplan",
-      "version": "1.0.117",
+      "version": "1.0.124",
       "license": "GPLV3",
       "dependencies": {
         "@graphql-tools/schema": "^8.5.1",
@@ -18,7 +18,7 @@
         "jsonwebtoken": "^8.5.1",
         "moment": "^2.29.1",
         "ramda": "^0.27.1",
-        "ti2": "^1.0.111",
+        "ti2": "^1.0.118",
         "underscore": "^1.13.4",
         "xml-js": "^1.6.11",
         "xml2js": "^0.4.23"
@@ -8143,9 +8143,9 @@
       }
     },
     "node_modules/ti2": {
-      "version": "1.0.111",
-      "resolved": "https://registry.npmjs.org/ti2/-/ti2-1.0.111.tgz",
-      "integrity": "sha512-+H7TsN7vs9eI+fAdlVM8dCERRrmXcelx4h6/g2Ah7UwfYorwm+NcEl87qjO8DgPcMkcqFF/URBPhCx4eFyTagg==",
+      "version": "1.0.118",
+      "resolved": "https://registry.npmjs.org/ti2/-/ti2-1.0.118.tgz",
+      "integrity": "sha512-K42J+H8kBCoHpHGLwaniKWNmhuaVgJtB3G7xxWVp5qKipiLtsSg6q776u5mNDSMbPla0L7JiPe7+DqTQ7BDsSQ==",
       "dependencies": {
         "axios": "^0.27.2",
         "axios-curlirize": "^1.3.7",
@@ -15017,9 +15017,9 @@
       }
     },
     "ti2": {
-      "version": "1.0.111",
-      "resolved": "https://registry.npmjs.org/ti2/-/ti2-1.0.111.tgz",
-      "integrity": "sha512-+H7TsN7vs9eI+fAdlVM8dCERRrmXcelx4h6/g2Ah7UwfYorwm+NcEl87qjO8DgPcMkcqFF/URBPhCx4eFyTagg==",
+      "version": "1.0.118",
+      "resolved": "https://registry.npmjs.org/ti2/-/ti2-1.0.118.tgz",
+      "integrity": "sha512-K42J+H8kBCoHpHGLwaniKWNmhuaVgJtB3G7xxWVp5qKipiLtsSg6q776u5mNDSMbPla0L7JiPe7+DqTQ7BDsSQ==",
       "requires": {
         "axios": "^0.27.2",
         "axios-curlirize": "^1.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2-tourplan",
-  "version": "1.0.123",
+  "version": "1.0.124",
   "description": "Tourplan's TI2 Plugin",
   "main": "index.js",
   "scripts": {
@@ -39,7 +39,7 @@
     "jsonwebtoken": "^8.5.1",
     "moment": "^2.29.1",
     "ramda": "^0.27.1",
-    "ti2": "^1.0.111",
+    "ti2": "^1.0.118",
     "underscore": "^1.13.4",
     "xml-js": "^1.6.11",
     "xml2js": "^0.4.23"


### PR DESCRIPTION
Adds a new `confirmBooking` method that converts a Tourplan quote into a confirmed booking via the HostConnect `QuoteToBookRequest` API. When a quote is confirmed, inventory is allocated per service line and the reply includes a `ServiceStatus` per line indicating whether allocation succeeded.

- Sends `QuoteToBookRequest` with `AgentID`, `Password`, and booking identifier (`BookingId` or `Ref`).
- Returns:
  - `confirmBookingReply` — raw parsed `QuoteToBookReply` object
  - `booking` — normalized object:
    - `ref` from `Ref`
    - `id` from `BookingId` (falls back to the identifier sent)
    - `status` — aggregate across all service line statuses (`OK`, `MIXED`, etc.) with fallbacks to `BookingStatus`, `Status`, `payload.status`, then `'Confirmed'`
    - `serviceLines` — array of `{ ref, serviceLineId, date, sequenceNumber, status }`

- Extracts shared utilities used by both cancel and confirm:
  - `getBookingIdentifier(payload)` — resolves `bookingId`/`id` → `BookingId` field, `ref`/`reference` → `Ref` field (with XML escaping)
  - `toServiceStatusArray(reply)` — normalises single-object and array forms of `ServiceStatuses.ServiceStatus` from fast-xml-parser
  - `getAggregateServiceStatus(reply)` — returns the single status when all lines agree, or `'MIXED'` when they differ
  - `mapServiceStatusLines(reply)` — maps each line to a plain object

- Replaced inline `getIdentifier` and `getAggregateServiceStatus` with imports from `itinerary-hostconnect-helpers` (no behaviour change).
- Removed the now-redundant `escapeInvalidXmlChars` import.

- Imports `confirmBooking` from `itinerary-confirm-booking`.
- Exposes `confirmBooking()` method on `BuyerPlugin`, following the same pattern as `cancelBooking` and `addServiceToItinerary`.

- 5 new `confirmBooking` tests:
  - converts a quote to a booking by id (asserts request shape + full normalised response)
  - converts a quote to a booking by ref
  - returns `MIXED` status when service line statuses differ
  - throws when no booking id or reference is provided
  - falls back to `'Confirmed'` when `ServiceStatuses` is absent
- 1 new `cancelBooking` test: throws when no identifier is provided

- Documents the `confirmBooking` HostConnect request/response XML, equivalent curl command, and plugin return shape.

- Version bumped 1.0.123 → 1.0.124