### PR TITLE
[TC-1336] feat: add optionId fast path and OptRates passthrough in searchProductsForItinerary

### DIFF
--- a/__fixtures__/OptionInfoRequest_4f8b93072db9a52be70dc1f563c4b374de4eb0e6.txt
+++ b/__fixtures__/OptionInfoRequest_4f8b93072db9a52be70dc1f563c4b374de4eb0e6.txt
@@ -1,0 +1,77 @@
+<!-- LONTRDAVIDSHDWBVD: Fixture for searchProductsForItinerary Test -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Reply SYSTEM "http://localhost:8080/iCom_Test/hostConnect_4_06_009.dtd">
+<Reply>
+    <OptionInfoReply>
+        <Option>
+            <Opt>LONTRDAVIDSHDWBVD</Opt>
+            <OptionNumber>70820</OptionNumber>
+            <OptGeneral>
+                <SupplierId>6489</SupplierId>
+                <SupplierName>Davids of London Ltd</SupplierName>
+                <Description>Half-Day Warner Bros Studios (6-Hours)</Description>
+                <Comment>FIT- V- Class (1-5 Pax)</Comment>
+                <Locality>LON</Locality>
+                <LocalityDescription>London</LocalityDescription>
+                <SType>N</SType>
+                <MPFCU>5</MPFCU>
+                <SCU>day</SCU>
+                <MinSCU>1</MinSCU>
+                <MaxSCU>9999</MaxSCU>
+                <VoucherName>Davids of London Ltd</VoucherName>
+                <Address1>377 Fulham Palace Road</Address1>
+                <Address2></Address2>
+                <Address3>London</Address3>
+                <Address4>United Kingdom</Address4>
+                <Address5></Address5>
+                <PostCode>SW6 6TA</PostCode>
+                <InfantsAllowed>Y</InfantsAllowed>
+                <Infant_From>0</Infant_From>
+                <Infant_To>4</Infant_To>
+                <ChildrenAllowed>Y</ChildrenAllowed>
+                <Child_From>5</Child_From>
+                <Child_To>15</Child_To>
+                <AdultsAllowed>Y</AdultsAllowed>
+                <Adult_From>16</Adult_From>
+                <Adult_To>999</Adult_To>
+                <ButtonName>Transfers</ButtonName>
+                <DBAnalysisCode1>FI</DBAnalysisCode1>
+                <DBAnalysisDescription1>FIT</DBAnalysisDescription1>
+                <DBAnalysisCode2>GB</DBAnalysisCode2>
+                <DBAnalysisDescription2>United Kingdom</DBAnalysisDescription2>
+                <DBAnalysisCode3>20</DBAnalysisCode3>
+                <DBAnalysisDescription3>VAT 20%</DBAnalysisDescription3>
+                <DBAnalysisCode4></DBAnalysisCode4>
+                <DBAnalysisDescription4>Unassigned</DBAnalysisDescription4>
+                <DBAnalysisCode5></DBAnalysisCode5>
+                <DBAnalysisDescription5>Unassigned</DBAnalysisDescription5>
+                <DBAnalysisCode6></DBAnalysisCode6>
+                <DBAnalysisDescription6>Unassigned</DBAnalysisDescription6>
+                <LastUpdate>2023-11-23T14:34:53Z</LastUpdate>
+            </OptGeneral>
+            <OptRates>
+                <Currency>GBP</Currency>
+                <PaxBreaks>
+                    <PaxBreak>1</PaxBreak>
+                </PaxBreaks>
+                <CancelPolicies>
+                    <CancelPenalty>
+                        <CancelRuleType>Percent</CancelRuleType>
+                        <CancelRuleUnits>100.00</CancelRuleUnits>
+                    </CancelPenalty>
+                </CancelPolicies>
+                <SaleFrom>2026-01-01</SaleFrom>
+                <SaleTo>2026-12-31</SaleTo>
+                <OptRate>
+                    <Date>2026-06-01</Date>
+                    <RateName>STD</RateName>
+                    <RateText>Standard</RateText>
+                    <CommissionPercent>10.00</CommissionPercent>
+                    <PersonRates>
+                        <AdultRate>10000</AdultRate>
+                    </PersonRates>
+                </OptRate>
+            </OptRates>
+        </Option>
+    </OptionInfoReply>
+</Reply>

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -4153,6 +4153,29 @@ Object {
           "comment": "FIT- V- Class (1-5 Pax)",
           "extras": Array [],
           "lastUpdateTimestamp": 1700750093,
+          "optRates": Object {
+            "CancelPolicies": Object {
+              "CancelPenalty": Object {
+                "CancelRuleType": "Percent",
+                "CancelRuleUnits": 100,
+              },
+            },
+            "Currency": "GBP",
+            "OptRate": Object {
+              "CommissionPercent": 10,
+              "Date": "2026-06-01",
+              "PersonRates": Object {
+                "AdultRate": 10000,
+              },
+              "RateName": "STD",
+              "RateText": "Standard",
+            },
+            "PaxBreaks": Object {
+              "PaxBreak": 1,
+            },
+            "SaleFrom": "2026-01-01",
+            "SaleTo": "2026-12-31",
+          },
           "optionId": "LONTRDAVIDSHDWBVD",
           "optionName": "Half-Day Warner Bros Studios (6-Hours)-FIT- V- Class (1-5 Pax)",
           "restrictions": Object {

--- a/itinerary-products-search.js
+++ b/itinerary-products-search.js
@@ -18,7 +18,6 @@ const searchProductsForItinerary = async ({
   payload: {
     // single optionId or array of optionIds
     optionId,
-    forceRefresh,
     searchInput,
     // lastUpdatedFrom is used to get options that were updated after a certain date in Tourplan
     // example: lastUpdatedFrom: '2024-04-22 05:17:57.427Z'
@@ -26,55 +25,84 @@ const searchProductsForItinerary = async ({
   },
   callTourplan,
 }) => {
-  /*
-    Pseudo
-    1. getServiceCodes -> [AC, BD]
-    2. for each serviceCode getoptions
-    3. convert them to ti2 products structure
-    4. merge all products from all serviceCodes
-  */
-  // getServices
-  const getServicesModel = {
-    GetServicesRequest: {
-      AgentID: hostConnectAgentID,
-      Password: hostConnectAgentPassword,
-    },
-  };
-  const getServicesReply = await callTourplan({
-    model: getServicesModel,
-    endpoint: hostConnectEndpoint,
-    axios,
-    xmlOptions: hostConnectXmlOptions,
-  });
-  let serviceCodes = R.pathOr([], ['GetServicesReply', 'TPLServices', 'TPLService'], getServicesReply);
-  if (!Array.isArray(serviceCodes)) serviceCodes = [serviceCodes];
-  serviceCodes = serviceCodes.map(s => s.Code);
+  // Normalise optionId to an array (or empty)
+  const optionIds = optionId
+    ? (Array.isArray(optionId) ? optionId : [optionId]).filter(Boolean)
+    : [];
+
   let options = [];
-  await Promise.each(serviceCodes, async serviceCode => {
-    const getOptionsModel = {
-      OptionInfoRequest: {
-        Opt: `???${serviceCode}????????????`,
-        Info: 'G',
+
+  if (optionIds.length > 0) {
+    // Fast path: fetch only the requested option(s) by their exact Opt code,
+    // skipping the expensive full-catalog GetServices + wildcard OptionInfo calls.
+    await Promise.each(optionIds, async id => {
+      const getOptionsModel = {
+        OptionInfoRequest: {
+          Opt: id,
+          Info: 'GR',
+          AgentID: hostConnectAgentID,
+          Password: hostConnectAgentPassword,
+        },
+      };
+      const getOptionsReply = await callTourplan({
+        model: getOptionsModel,
+        endpoint: hostConnectEndpoint,
+        axios,
+        xmlOptions: hostConnectXmlOptions,
+      });
+      let thisOptions = R.pathOr([], ['OptionInfoReply', 'Option'], getOptionsReply);
+      if (!Array.isArray(thisOptions)) thisOptions = [thisOptions];
+      options = options.concat(thisOptions);
+    });
+  } else {
+    /*
+      Full catalog path:
+      1. getServiceCodes -> [AC, BD]
+      2. for each serviceCode getoptions
+      3. convert them to ti2 products structure
+      4. merge all products from all serviceCodes
+    */
+    // getServices
+    const getServicesModel = {
+      GetServicesRequest: {
         AgentID: hostConnectAgentID,
         Password: hostConnectAgentPassword,
-        ...(lastUpdatedFrom ? {
-          LastUpdateFrom: lastUpdatedFrom,
-        } : {}),
       },
     };
-    const getOptionsReply = await callTourplan({
-      model: getOptionsModel,
+    const getServicesReply = await callTourplan({
+      model: getServicesModel,
       endpoint: hostConnectEndpoint,
       axios,
       xmlOptions: hostConnectXmlOptions,
     });
-    let thisOptions = R.pathOr([], ['OptionInfoReply', 'Option'], getOptionsReply);
-    // due to the new parser, single option will be returned as an object
-    // instead of an array
-    if (!Array.isArray(thisOptions)) thisOptions = [thisOptions];
-    console.log(`got ${thisOptions.length} options for serviceCode ${serviceCode}`);
-    options = options.concat(thisOptions);
-  });
+    let serviceCodes = R.pathOr([], ['GetServicesReply', 'TPLServices', 'TPLService'], getServicesReply);
+    if (!Array.isArray(serviceCodes)) serviceCodes = [serviceCodes];
+    serviceCodes = serviceCodes.map(s => s.Code);
+    await Promise.each(serviceCodes, async serviceCode => {
+      const getOptionsModel = {
+        OptionInfoRequest: {
+          Opt: `???${serviceCode}????????????`,
+          Info: 'G',
+          AgentID: hostConnectAgentID,
+          Password: hostConnectAgentPassword,
+          ...(lastUpdatedFrom ? {
+            LastUpdateFrom: lastUpdatedFrom,
+          } : {}),
+        },
+      };
+      const getOptionsReply = await callTourplan({
+        model: getOptionsModel,
+        endpoint: hostConnectEndpoint,
+        axios,
+        xmlOptions: hostConnectXmlOptions,
+      });
+      let thisOptions = R.pathOr([], ['OptionInfoReply', 'Option'], getOptionsReply);
+      // due to the new parser, single option will be returned as an object
+      // instead of an array
+      if (!Array.isArray(thisOptions)) thisOptions = [thisOptions];
+      options = options.concat(thisOptions);
+    });
+  }
   if (!(options && options.length)) {
     throw new Error('No products found');
   }
@@ -95,8 +123,27 @@ const searchProductsForItinerary = async ({
       concurrency: 10,
     },
   );
+  // Preserve raw OptRates from Tourplan in product search response when available.
+  const optionRatesByOptionId = options.reduce((acc, option) => {
+    const currentOptionId = R.path(['Opt'], option);
+    const currentOptionRates = R.path(['OptRates'], option);
+    if (!currentOptionId || !currentOptionRates) return acc;
+    return {
+      ...acc,
+      [currentOptionId]: currentOptionRates,
+    };
+  }, {});
+  const productsWithOptRates = products.map(product => ({
+    ...product,
+    options: R.pathOr([], ['options'], product).map(currentOption => ({
+      ...currentOption,
+      ...(R.path([currentOption.optionId], optionRatesByOptionId)
+        ? { optRates: R.path([currentOption.optionId], optionRatesByOptionId) }
+        : {}),
+    })),
+  }));
   return {
-    products,
+    products: productsWithOptRates,
     productFields: [],
     ...(searchInput || optionId ? {} : configuration),
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2-tourplan",
-  "version": "1.0.124",
+  "version": "1.0.125",
   "description": "Tourplan's TI2 Plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When optionId is provided, skip the expensive GetServices + wildcard OptionInfo catalog fetch and query only the requested option(s) directly using Info: GR (General + Rates). For all flows, preserve raw OptRates from the Tourplan response as optRates on each returned option when available. Full-catalog path behavior is unchanged.