### PR TITLE
[TC-1297] Return OptRates from availabilityOnly GAR response in searchAvailabilityForItinerary

### DIFF
--- a/availability/itinerary-availability-helper.js
+++ b/availability/itinerary-availability-helper.js
@@ -172,7 +172,7 @@ const getAvailabilityOnly = async ({
   const model = {
     OptionInfoRequest: {
       Opt: optionId,
-      Info: 'AD',
+      Info: 'GAR',
       AgentID: hostConnectAgentID,
       Password: hostConnectAgentPassword,
       DateFrom: startDate,
@@ -186,7 +186,11 @@ const getAvailabilityOnly = async ({
     axios,
     xmlOptions: hostConnectXmlOptions,
   });
-  return R.pathOr([], ['OptionInfoReply', 'Option', 'OptAvail'], replyObj);
+  const option = R.path(['OptionInfoReply', 'Option'], replyObj);
+  return {
+    optAvail: R.pathOr([], ['OptAvail'], option),
+    optRates: R.path(['OptRates'], option),
+  };
 };
 /*
     Get general option information from Tourplan API.

--- a/availability/itinerary-availability.js
+++ b/availability/itinerary-availability.js
@@ -152,7 +152,7 @@ const searchAvailabilityForItinerary = async ({
   const isAvailabilityOnly = availabilityOnly === true;
 
   if (isAvailabilityOnly) {
-    const availabilityOnlyResponse = await getAvailabilityOnly({
+    const { optAvail, optRates } = await getAvailabilityOnly({
       optionId,
       hostConnectEndpoint,
       hostConnectAgentID,
@@ -162,8 +162,9 @@ const searchAvailabilityForItinerary = async ({
       requestedEndDate,
       callTourplan,
     });
-    const optAvailValues = getOptAvailValues(availabilityOnlyResponse);
+    const optAvailValues = getOptAvailValues(optAvail);
     const SCheckPass = isOptAvailBookable(optAvailValues);
+    const rates = (SCheckPass && optRates) ? [optRates] : [];
     return {
       bookable: SCheckPass,
       type: 'availability',
@@ -172,7 +173,7 @@ const searchAvailabilityForItinerary = async ({
         ? 'Availability checked successfully'
         : 'No availability found for the requested range',
       availability: optAvailValues,
-      rates: [],
+      rates,
     };
   }
 

--- a/availability/itinerary-availability.validation-flags.test.js
+++ b/availability/itinerary-availability.validation-flags.test.js
@@ -24,7 +24,7 @@ jest.mock('./itinerary-availability-helper', () => ({
     maxPaxPerCharge: null,
   })),
   getNoRatesAvailableError: jest.fn(async () => 'No rates available'),
-  getAvailabilityOnly: jest.fn(async () => '-1 -1 -1'),
+  getAvailabilityOnly: jest.fn(async () => ({ optAvail: '-1 -1 -1', optRates: null })),
   getStayResults: jest.fn(async () => ([{
     RateId: 'R1',
     Currency: 'USD',
@@ -149,7 +149,18 @@ describe('searchAvailabilityForItinerary validation flags', () => {
   });
 
   it('uses availabilityOnly flow and keeps response shape consistent', async () => {
-    itineraryAvailabilityHelper.getAvailabilityOnly.mockResolvedValueOnce('-1 -2 -1');
+    const mockOptRates = {
+      Currency: 'JPY',
+      OptRate: {
+        Date: '2026-06-01',
+        RateName: '26年',
+        PersonRates: { AdultRate: 2700000, ChildRate: 1700000 },
+      },
+    };
+    itineraryAvailabilityHelper.getAvailabilityOnly.mockResolvedValueOnce({
+      optAvail: '-1 -2 -1',
+      optRates: mockOptRates,
+    });
 
     const result = await searchAvailabilityForItinerary({
       axios: jest.fn(),
@@ -160,6 +171,7 @@ describe('searchAvailabilityForItinerary validation flags', () => {
     });
 
     expect(itineraryAvailabilityHelper.getAvailabilityOnly).toHaveBeenCalledTimes(1);
+    expect(itineraryAvailabilityHelper.getStayResults).not.toHaveBeenCalled();
     expect(itineraryAvailabilityHelper.getAgentCurrencyCode).not.toHaveBeenCalled();
     expect(result).toEqual({
       bookable: true,
@@ -167,12 +179,15 @@ describe('searchAvailabilityForItinerary validation flags', () => {
       endDate: '2025-04-05',
       message: 'Availability checked successfully',
       availability: [-1, -2, -1],
-      rates: [],
+      rates: [mockOptRates],
     });
   });
 
   it('marks availabilityOnly response as not bookable when all days are unavailable', async () => {
-    itineraryAvailabilityHelper.getAvailabilityOnly.mockResolvedValueOnce('-1 -1 -1');
+    itineraryAvailabilityHelper.getAvailabilityOnly.mockResolvedValueOnce({
+      optAvail: '-1 -1 -1',
+      optRates: null,
+    });
 
     const result = await searchAvailabilityForItinerary({
       axios: jest.fn(),
@@ -186,5 +201,6 @@ describe('searchAvailabilityForItinerary validation flags', () => {
     expect(result.message).toBe('No availability found for the requested range');
     expect(result.availability).toEqual([-1, -1, -1]);
     expect(result.rates).toEqual([]);
+    expect(itineraryAvailabilityHelper.getStayResults).not.toHaveBeenCalled();
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2-tourplan",
-  "version": "1.0.125",
+  "version": "1.0.126",
   "description": "Tourplan's TI2 Plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Switch getAvailabilityOnly to Info: GAR and expose optAvail and optRates from the same Tourplan call, so availabilityOnly responses include raw OptRates when bookable without a separate stay-pricing request.