### PR TITLE
Limit outbound Tourplan booking names

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -168,6 +168,46 @@ describe('search tests', () => {
         expect(newBookingName.length).toBe(59);
         expect(newBookingName).toBe(`${'Ae'.repeat(29)}A`);
       });
+
+      it('limits new booking names supplied by directHeaderPayload after escaping XML characters', async () => {
+        mockCallTourplan.mockImplementationOnce(async () => ({
+          AddServiceReply: {
+            BookingId: '12345',
+            Ref: 'TESTREF',
+            Services: {
+              Service: {
+                LinePrice: '10.00',
+              },
+            },
+            ServiceLineId: '10',
+          },
+        }));
+
+        await app.addServiceToItinerary({
+          axios,
+          token,
+          payload: {
+            quoteName: 'Short quote name',
+            optionId: 'ABC123',
+            startDate: '2026-07-03',
+            reference: 'TESTREF',
+            paxConfigs: [{ roomType: 'Double', adults: 2 }],
+            notes: '',
+            directHeaderPayload: {
+              Name: 'Ä'.repeat(30),
+              HeaderField: 'kept',
+            },
+          },
+        });
+
+        expect(mockCallTourplan).toHaveBeenCalledTimes(1);
+        const newBookingInfo = mockCallTourplan.mock.calls[0][0]
+          .model.AddServiceRequest.NewBookingInfo;
+
+        expect(newBookingInfo.Name.length).toBe(59);
+        expect(newBookingInfo.Name).toBe(`${'Ae'.repeat(29)}A`);
+        expect(newBookingInfo.HeaderField).toBe('kept');
+      });
     });
 
     describe('cancelBooking', () => {

--- a/index.test.js
+++ b/index.test.js
@@ -132,6 +132,44 @@ describe('search tests', () => {
         }
       });
     });
+    describe('addServiceToItinerary', () => {
+      it('limits new booking names after escaping XML characters', async () => {
+        mockCallTourplan.mockImplementationOnce(async () => ({
+          AddServiceReply: {
+            BookingId: '12345',
+            Ref: 'TESTREF',
+            Services: {
+              Service: {
+                LinePrice: '10.00',
+              },
+            },
+            ServiceLineId: '10',
+          },
+        }));
+
+        const quoteName = 'Ä'.repeat(30);
+        await app.addServiceToItinerary({
+          axios,
+          token,
+          payload: {
+            quoteName,
+            optionId: 'ABC123',
+            startDate: '2026-07-03',
+            reference: 'TESTREF',
+            paxConfigs: [{ roomType: 'Double', adults: 2 }],
+            notes: '',
+          },
+        });
+
+        expect(mockCallTourplan).toHaveBeenCalledTimes(1);
+        const newBookingName = mockCallTourplan.mock.calls[0][0]
+          .model.AddServiceRequest.NewBookingInfo.Name;
+
+        expect(newBookingName.length).toBe(59);
+        expect(newBookingName).toBe(`${'Ae'.repeat(29)}A`);
+      });
+    });
+
     describe('cancelBooking', () => {
       it('cancels a booking by id', async () => {
         mockCallTourplan.mockImplementationOnce(async () => ({

--- a/itinerary-add-service.js
+++ b/itinerary-add-service.js
@@ -8,7 +8,11 @@ const {
 } = require('./utils');
 
 const DEFAULT_TOURPLAN_SERVICE_STATUS = 'IR';
+const MAX_BOOKING_NAME_LENGTH = 59;
 const SERVICE_CANNOT_BE_ADDED_ERROR_MESSAGE = 'Service cannot be added to quote for the requested date/stay. (e.g. no rates, block out period, on request, minimum stay etc.)';
+
+const getBookingName = quoteName => escapeInvalidXmlChars(quoteName)
+  .substring(0, MAX_BOOKING_NAME_LENGTH);
 
 const addServiceToItinerary = async ({
   axios,
@@ -141,7 +145,7 @@ const addServiceToItinerary = async ({
         ExistingBookingInfo: { BookingId: quoteId },
       } : {
         NewBookingInfo: {
-          Name: escapeInvalidXmlChars(quoteName),
+          Name: getBookingName(quoteName),
           QB: QB || 'Q',
           ...(directHeaderPayload || {}),
         },

--- a/itinerary-add-service.js
+++ b/itinerary-add-service.js
@@ -65,6 +65,10 @@ const addServiceToItinerary = async ({
       return acc;
     }, {});
 
+  const directHeaderPayloadHasName = directHeaderPayload &&
+    Object.prototype.hasOwnProperty.call(directHeaderPayload, 'Name');
+  const bookingNameSource = directHeaderPayloadHasName ? directHeaderPayload.Name : quoteName;
+
   const rateIdFromAvailCheckObj = R.path(['rateId'], availCheckObj);
   if (availCheckObj &&
     (rateIdFromAvailCheckObj === CUSTOM_RATE_ID_NAME
@@ -145,9 +149,9 @@ const addServiceToItinerary = async ({
         ExistingBookingInfo: { BookingId: quoteId },
       } : {
         NewBookingInfo: {
-          Name: getBookingName(quoteName),
           QB: QB || 'Q',
           ...(directHeaderPayload || {}),
+          Name: getBookingName(bookingNameSource),
         },
       }),
       ...(puTime ? { puTime } : {}),


### PR DESCRIPTION
## Summary
- Limit outbound create-booking names to 59 characters after existing XML character normalization.
- Add focused Jest coverage for overlong booking names.

## Validation
- `npm test -- index.test.js --forceExit -t 'limits new booking names'`
- `npx eslint itinerary-add-service.js`