### PR TITLE
feat: add skipAccommodation flag to omit AC from full catalog product search

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -799,6 +799,68 @@ describe('search tests', () => {
     expect(retVal).toMatchSnapshot();
   });
 
+  it('searchProductsForItinerary skips AC in full catalog when skipAccommodation is set', async () => {
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    const bdOption = {
+      Opt: 'TESTBDOPTION00001',
+      OptGeneral: {
+        SupplierId: '1001',
+        SupplierName: 'Test Supplier',
+        Description: 'Test BD Product',
+        SType: 'N',
+        AdultsAllowed: 'Y',
+        Adult_From: 16,
+        Adult_To: 999,
+        ButtonName: 'Sightseeing',
+      },
+    };
+
+    mockCallTourplan
+      .mockImplementationOnce(async () => ({
+        GetServicesReply: {
+          TPLServices: {
+            TPLService: [
+              { Code: 'AC', Name: 'Accommodation' },
+              { Code: 'BD', Name: 'Bundle' },
+            ],
+          },
+        },
+      }))
+      .mockImplementationOnce(async ({ model }) => {
+        const opt = model.OptionInfoRequest.Opt;
+        if (opt === '???AC????????????') {
+          throw new Error('AC OptionInfo should have been skipped');
+        }
+        if (opt === '???BD????????????') {
+          return { OptionInfoReply: { Option: bdOption } };
+        }
+        throw new Error(`Unexpected OptionInfo Opt: ${opt}`);
+      });
+
+    const retVal = await app.searchProductsForItinerary({
+      axios,
+      token,
+      typeDefsAndQueries,
+      payload: {
+        searchInput: '',
+        skipAccommodation: true,
+      },
+    });
+
+    const optionInfoCalls = mockCallTourplan.mock.calls
+      .map(([call]) => call.model.OptionInfoRequest)
+      .filter(Boolean);
+    expect(optionInfoCalls).toHaveLength(1);
+    expect(optionInfoCalls[0].Opt).toBe('???BD????????????');
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[tourplan] Accommodation (AC) service code will be skipped in full catalog product search',
+    );
+    expect(retVal.products).toHaveLength(1);
+    expect(retVal.products[0].options[0].optionId).toBe('TESTBDOPTION00001');
+
+    debugSpy.mockRestore();
+  });
+
   describe('availability tests', () => {
     it('searchAvailabilityForItinerary - not bookable', async () => {
       axios.mockImplementation(getFixture);

--- a/itinerary-products-search.js
+++ b/itinerary-products-search.js
@@ -22,6 +22,8 @@ const searchProductsForItinerary = async ({
     // lastUpdatedFrom is used to get options that were updated after a certain date in Tourplan
     // example: lastUpdatedFrom: '2024-04-22 05:17:57.427Z'
     lastUpdatedFrom,
+    // skip Accommodation (AC) service code in full catalog search
+    skipAccommodation,
   },
   callTourplan,
 }) => {
@@ -58,7 +60,7 @@ const searchProductsForItinerary = async ({
     /*
       Full catalog path:
       1. getServiceCodes -> [AC, BD]
-      2. for each serviceCode getoptions
+      2. for each serviceCode getoptions (optionally skip AC when skipAccommodation is set)
       3. convert them to ti2 products structure
       4. merge all products from all serviceCodes
     */
@@ -77,7 +79,12 @@ const searchProductsForItinerary = async ({
     });
     let serviceCodes = R.pathOr([], ['GetServicesReply', 'TPLServices', 'TPLService'], getServicesReply);
     if (!Array.isArray(serviceCodes)) serviceCodes = [serviceCodes];
-    serviceCodes = serviceCodes.map(s => s.Code);
+    if (skipAccommodation) {
+      console.debug('[tourplan] Accommodation (AC) service code will be skipped in full catalog product search');
+    }
+    serviceCodes = serviceCodes
+      .map(s => s.Code)
+      .filter(code => !(skipAccommodation && code === 'AC'));
     await Promise.each(serviceCodes, async serviceCode => {
       const getOptionsModel = {
         OptionInfoRequest: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2-tourplan",
-  "version": "1.0.127",
+  "version": "1.0.128",
   "description": "Tourplan's TI2 Plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Allow callers to skip the Accommodation (AC) service code during GetServices catalog sync. Integrations are unchanged unless they pass the flag. This is particularly helpful for Bokun Channel Manager implementation as it does not use accommodation services via the BCM.
This was added to optimize the product search, which would timeout otherwise. A long term solution may be to search on location instead of service types. in some testing that seems to be more efficient. 